### PR TITLE
Audio history and reprocess from tray

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,7 @@ Sources/OpenWispr/
 ├── Config.swift         # Config loading/saving (~/.config/open-wispr/config.json)
 ├── Transcriber.swift    # Whisper CLI wrapper
 ├── AudioRecorder.swift  # Microphone recording
+├── RecordingStore.swift # Recording history and pruning
 └── ...
 scripts/
 ├── install.sh           # Guided installer

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ Edit `~/.config/open-wispr/config.json`:
   "hotkey": { "keyCode": 63, "modifiers": [] },
   "modelSize": "base.en",
   "language": "en",
-  "spokenPunctuation": false
+  "spokenPunctuation": false,
+  "maxRecordings": 10
 }
 ```
 
@@ -56,6 +57,7 @@ Then restart: `brew services restart open-wispr`
 | **modelSize** | `"base.en"` | `tiny.en` · `base.en` · `small.en` · `medium.en` (English-only) or `tiny` · `base` · `small` · `medium` (multilingual) |
 | **language** | `"en"` | Any [ISO 639-1 code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) — e.g. `it`, `fr`, `de`, `es` |
 | **spokenPunctuation** | `false` | Say "comma", "period", etc. to insert punctuation instead of auto-punctuation |
+| **maxRecordings** | `10` | Number of recent recordings to keep for reprocessing from the tray menu. Set to `0` for original privacy behavior: temp file, deleted immediately after transcription. Use 1–100 to enable the Recent Recordings feature. |
 
 > **Non-English languages:** Models ending in `.en` are English-only. To use another language, switch to the equivalent model without the `.en` suffix (e.g. `base.en` → `base`) and set the `language` field to your language code.
 
@@ -66,6 +68,8 @@ Then restart: `brew services restart open-wispr`
 If the Globe key opens the emoji picker: **System Settings → Keyboard → "Press 🌐 key to" → "Do Nothing"**
 
 ## Menu bar
+
+Click the waveform icon for status and options. **Recent Recordings** lists your last recordings; click one to re-transcribe and copy the result to the clipboard.
 
 | State | Icon |
 |---|---|
@@ -88,7 +92,7 @@ If the Globe key opens the emoji picker: **System Settings → Keyboard → "Pre
 
 ## Privacy
 
-open-wispr is completely local. Audio is recorded to a temp file, transcribed by whisper.cpp on your CPU/GPU, and the temp file is deleted. No network requests are made except to download the Whisper model on first run.
+open-wispr is completely local. Set `maxRecordings` to `0` for the original behavior: audio is recorded to a temp file, transcribed by whisper.cpp on your CPU/GPU, and the file is deleted immediately. With `maxRecordings` > 0 (default 10), recordings are stored in `~/.config/open-wispr/recordings/` for reprocessing from the tray menu; old recordings are pruned automatically. No network requests are made except to download the Whisper model on first run. Uninstall removes all recordings.
 
 ## Build from source
 

--- a/Sources/OpenWispr/AppDelegate.swift
+++ b/Sources/OpenWispr/AppDelegate.swift
@@ -33,7 +33,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         transcriber = Transcriber(modelSize: config.modelSize, language: config.language)
         transcriber.spokenPunctuation = config.spokenPunctuation?.value ?? false
 
-        DispatchQueue.main.async { self.statusBar.buildMenu() }
+        DispatchQueue.main.async {
+            self.statusBar.reprocessHandler = { [weak self] url in
+                self?.reprocess(audioURL: url)
+            }
+            self.statusBar.buildMenu()
+        }
 
         if Transcriber.findWhisperBinary() == nil {
             print("Error: whisper-cpp not found. Install it with: brew install whisper-cpp")
@@ -107,7 +112,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         isPressed = true
         statusBar.state = .recording
         do {
-            try recorder.startRecording()
+            let outputURL: URL
+            if Config.effectiveMaxRecordings(config.maxRecordings) == 0 {
+                outputURL = RecordingStore.tempRecordingURL()
+            } else {
+                outputURL = RecordingStore.newRecordingURL()
+            }
+            try recorder.startRecording(to: outputURL)
         } catch {
             print("Error: \(error.localizedDescription)")
             isPressed = false
@@ -128,18 +139,65 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             guard let self = self else { return }
+            let maxRecordings = Config.effectiveMaxRecordings(self.config.maxRecordings)
+            defer {
+                if maxRecordings == 0 {
+                    try? FileManager.default.removeItem(at: audioURL)
+                }
+            }
             do {
                 let raw = try self.transcriber.transcribe(audioURL: audioURL)
                 let text = (self.config.spokenPunctuation?.value ?? false) ? TextPostProcessor.process(raw) : raw
+                if maxRecordings > 0 {
+                    RecordingStore.prune(maxCount: maxRecordings)
+                }
                 DispatchQueue.main.async {
                     if !text.isEmpty {
                         self.inserter.insert(text: text)
                     }
                     self.statusBar.state = .idle
+                    self.statusBar.buildMenu()
+                }
+            } catch {
+                if maxRecordings > 0 {
+                    RecordingStore.prune(maxCount: maxRecordings)
+                }
+                DispatchQueue.main.async {
+                    print("Error: \(error.localizedDescription)")
+                    self.statusBar.state = .idle
+                    self.statusBar.buildMenu()
+                }
+            }
+        }
+    }
+
+    func reprocess(audioURL: URL) {
+        guard statusBar.state == .idle else { return }
+
+        statusBar.state = .transcribing
+
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            guard let self = self else { return }
+            do {
+                let raw = try self.transcriber.transcribe(audioURL: audioURL)
+                let text = (self.config.spokenPunctuation?.value ?? false) ? TextPostProcessor.process(raw) : raw
+                DispatchQueue.main.async {
+                    if !text.isEmpty {
+                        NSPasteboard.general.clearContents()
+                        NSPasteboard.general.setString(text, forType: .string)
+                        self.statusBar.state = .copiedToClipboard
+                        self.statusBar.buildMenu()
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                            self.statusBar.state = .idle
+                            self.statusBar.buildMenu()
+                        }
+                    } else {
+                        self.statusBar.state = .idle
+                    }
                 }
             } catch {
                 DispatchQueue.main.async {
-                    print("Error: \(error.localizedDescription)")
+                    print("Reprocess error: \(error.localizedDescription)")
                     self.statusBar.state = .idle
                 }
             }

--- a/Sources/OpenWispr/AudioRecorder.swift
+++ b/Sources/OpenWispr/AudioRecorder.swift
@@ -5,13 +5,9 @@ class AudioRecorder {
     private var audioEngine: AVAudioEngine?
     private var audioFile: AVAudioFile?
     private var isRecording = false
-    private let outputURL: URL
+    private var currentOutputURL: URL?
 
-    init() {
-        outputURL = FileManager.default.temporaryDirectory.appendingPathComponent("open-wispr-recording.wav")
-    }
-
-    func startRecording() throws {
+    func startRecording(to outputURL: URL) throws {
         guard !isRecording else { return }
 
         let engine = AVAudioEngine()
@@ -25,10 +21,6 @@ class AudioRecorder {
             interleaved: false
         )!
 
-        if FileManager.default.fileExists(atPath: outputURL.path) {
-            try FileManager.default.removeItem(at: outputURL)
-        }
-
         let settings: [String: Any] = [
             AVFormatIDKey: kAudioFormatLinearPCM,
             AVSampleRateKey: 16000,
@@ -39,6 +31,7 @@ class AudioRecorder {
         ]
 
         audioFile = try AVAudioFile(forWriting: outputURL, settings: settings)
+        currentOutputURL = outputURL
 
         let converter = AVAudioConverter(from: format, to: recordingFormat)
 
@@ -79,6 +72,6 @@ class AudioRecorder {
         audioFile = nil
         isRecording = false
 
-        return outputURL
+        return currentOutputURL
     }
 }

--- a/Sources/OpenWispr/Config.swift
+++ b/Sources/OpenWispr/Config.swift
@@ -6,13 +6,23 @@ struct Config: Codable {
     var modelSize: String
     var language: String
     var spokenPunctuation: FlexBool?
+    var maxRecordings: Int?
+
+    static let defaultMaxRecordings = 10
+
+    static func effectiveMaxRecordings(_ value: Int?) -> Int {
+        let raw = value ?? Config.defaultMaxRecordings
+        if raw == 0 { return 0 }
+        return min(max(1, raw), 100)
+    }
 
     static let defaultConfig = Config(
         hotkey: HotkeyConfig(keyCode: 63, modifiers: []),
         modelPath: nil,
         modelSize: "base.en",
         language: "en",
-        spokenPunctuation: FlexBool(false)
+        spokenPunctuation: FlexBool(false),
+        maxRecordings: nil
     )
 
     static var configDir: URL {

--- a/Sources/OpenWispr/RecordingStore.swift
+++ b/Sources/OpenWispr/RecordingStore.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+struct Recording {
+    let url: URL
+    let date: Date
+}
+
+class RecordingStore {
+    static let recordingsDir = Config.configDir.appendingPathComponent("recordings")
+
+    private static let filePrefix = "recording-"
+    private static let fileExtension = "wav"
+    private static let dateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd-HHmmss"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        return f
+    }()
+
+    static func ensureDirectory() {
+        do {
+            try FileManager.default.createDirectory(at: recordingsDir, withIntermediateDirectories: true)
+        } catch {
+            fputs("Warning: could not create recordings directory: \(error.localizedDescription)\n", stderr)
+        }
+    }
+
+    static func tempRecordingURL() -> URL {
+        FileManager.default.temporaryDirectory.appendingPathComponent("open-wispr-recording.wav")
+    }
+
+    static func newRecordingURL() -> URL {
+        ensureDirectory()
+        let timestamp = dateFormatter.string(from: Date())
+        let unique = String(UUID().uuidString.prefix(8))
+        let filename = "\(filePrefix)\(timestamp)-\(unique).\(fileExtension)"
+        return recordingsDir.appendingPathComponent(filename)
+    }
+
+    static func listRecordings() -> [Recording] {
+        ensureDirectory()
+        let fm = FileManager.default
+        guard let files = try? fm.contentsOfDirectory(at: recordingsDir, includingPropertiesForKeys: [.creationDateKey]) else {
+            return []
+        }
+
+        return files
+            .filter { $0.pathExtension.lowercased() == fileExtension && $0.lastPathComponent.hasPrefix(filePrefix) }
+            .compactMap { url -> Recording? in
+                let name = url.deletingPathExtension().lastPathComponent
+                let dateString = String(name.dropFirst(filePrefix.count))
+                let datePart = String(dateString.prefix(17))
+                guard let date = dateFormatter.date(from: datePart) else { return nil }
+                return Recording(url: url, date: date)
+            }
+            .sorted { $0.date > $1.date }
+    }
+
+    static func prune(maxCount: Int) {
+        let recordings = listRecordings()
+        guard recordings.count > maxCount else { return }
+
+        let toRemove = recordings.suffix(from: maxCount)
+        for recording in toRemove {
+            do {
+                try FileManager.default.removeItem(at: recording.url)
+            } catch {
+                fputs("Warning: could not remove old recording \(recording.url.path): \(error.localizedDescription)\n", stderr)
+            }
+        }
+    }
+}

--- a/Sources/OpenWispr/StatusBarController.swift
+++ b/Sources/OpenWispr/StatusBarController.swift
@@ -1,11 +1,20 @@
 import AppKit
 
+class MenuItemTarget: NSObject {
+    let handler: () -> Void
+    init(handler: @escaping () -> Void) { self.handler = handler }
+    @objc func invoke() { handler() }
+}
+
 class StatusBarController {
     private var statusItem: NSStatusItem
     private var animationTimer: Timer?
     private var animationFrame = 0
     private var animationFrames: [NSImage] = []
     private var downloadProgress: String?
+    private var menuItemTargets: [MenuItemTarget] = []
+
+    var reprocessHandler: ((URL) -> Void)?
 
     enum State {
         case idle
@@ -13,6 +22,7 @@ class StatusBarController {
         case transcribing
         case downloading
         case waitingForPermission
+        case copiedToClipboard
     }
 
     var state: State = .idle {
@@ -35,7 +45,16 @@ class StatusBarController {
         buildMenu()
     }
 
+    private static let displayDateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateStyle = .medium
+        f.timeStyle = .short
+        return f
+    }()
+
     func buildMenu() {
+        menuItemTargets = []
+
         let config = Config.load()
         let hotkeyDesc = KeyCodes.describe(keyCode: config.hotkey.keyCode, modifiers: config.hotkey.modifiers)
 
@@ -61,6 +80,7 @@ class StatusBarController {
         case .transcribing: stateText = "Transcribing..."
         case .downloading: stateText = "Downloading model..."
         case .waitingForPermission: stateText = "Waiting for Accessibility permission..."
+        case .copiedToClipboard: stateText = "Copied to clipboard"
         }
         let stateItem = NSMenuItem(title: stateText, action: nil, keyEquivalent: "")
         stateItem.isEnabled = false
@@ -75,6 +95,33 @@ class StatusBarController {
         let modelItem = NSMenuItem(title: "Model: \(config.modelSize)", action: nil, keyEquivalent: "")
         modelItem.isEnabled = false
         menu.addItem(modelItem)
+
+        menu.addItem(NSMenuItem.separator())
+
+        let recordings = RecordingStore.listRecordings()
+        let reprocessItem = NSMenuItem(title: "Recent Recordings", action: nil, keyEquivalent: "")
+        let submenu = NSMenu()
+
+        if recordings.isEmpty {
+            let emptyItem = NSMenuItem(title: "No recordings", action: nil, keyEquivalent: "")
+            emptyItem.isEnabled = false
+            submenu.addItem(emptyItem)
+        } else {
+            for (index, recording) in recordings.enumerated() {
+                let dateStr = StatusBarController.displayDateFormatter.string(from: recording.date)
+                let label = "\(dateStr) (\(index + 1))"
+                let target = MenuItemTarget { [weak self] in
+                    self?.reprocessHandler?(recording.url)
+                }
+                menuItemTargets.append(target)
+                let item = NSMenuItem(title: label, action: #selector(MenuItemTarget.invoke), keyEquivalent: "")
+                item.target = target
+                submenu.addItem(item)
+            }
+        }
+
+        reprocessItem.submenu = submenu
+        menu.addItem(reprocessItem)
 
         menu.addItem(NSMenuItem.separator())
         menu.addItem(NSMenuItem(title: "Quit", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q"))
@@ -96,6 +143,8 @@ class StatusBarController {
             startDownloadingAnimation()
         case .waitingForPermission:
             setIcon(StatusBarController.drawLockIcon())
+        case .copiedToClipboard:
+            setIcon(StatusBarController.drawCheckmarkIcon())
         }
     }
 
@@ -314,6 +363,29 @@ class StatusBarController {
             shacklePath.lineWidth = 1.8
             shacklePath.lineCapStyle = .round
             shacklePath.stroke()
+
+            return true
+        }
+        image.isTemplate = true
+        return image
+    }
+
+    static func drawCheckmarkIcon() -> NSImage {
+        let size = NSSize(width: 18, height: 18)
+        let image = NSImage(size: size, flipped: false) { rect in
+            NSColor.black.setStroke()
+
+            let centerX = rect.midX
+            let centerY = rect.midY
+
+            let path = NSBezierPath()
+            path.move(to: NSPoint(x: centerX - 5, y: centerY - 1))
+            path.line(to: NSPoint(x: centerX - 2, y: centerY + 3))
+            path.line(to: NSPoint(x: centerX + 5, y: centerY - 4))
+            path.lineWidth = 2.0
+            path.lineCapStyle = .round
+            path.lineJoinStyle = .round
+            path.stroke()
 
             return true
         }

--- a/index.html
+++ b/index.html
@@ -821,14 +821,15 @@
 
 <section class="config">
   <p class="section-tag">Configuration</p>
-  <h2>One file. Five options.</h2>
+  <h2>One file. Six options.</h2>
   <div class="config-example">
     <div class="card-header">~/.config/open-wispr/config.json</div>
     <pre>{
   "<b>hotkey</b>": { "<b>keyCode</b>": 63, "<b>modifiers</b>": [] },
   "<b>modelSize</b>": "base.en",
   "<b>language</b>": "en",
-  "<b>spokenPunctuation</b>": false
+  "<b>spokenPunctuation</b>": false,
+  "<b>maxRecordings</b>": 10
 }</pre>
   </div>
   <table class="config-table">
@@ -858,6 +859,11 @@
       <td>false</td>
       <td>Say "comma", "period", etc. to insert punctuation manually instead of auto-punctuation.</td>
     </tr>
+    <tr>
+      <td>maxRecordings</td>
+      <td>10</td>
+      <td>Set to 0 for original privacy: temp file, deleted immediately. Use 1–100 to keep recordings for reprocessing from the tray menu.</td>
+    </tr>
   </table>
   <p class="config-note">Edit <code>~/.config/open-wispr/config.json</code>, then restart: <code>brew services restart open-wispr</code></p>
 </section>
@@ -881,7 +887,7 @@
     </details>
     <details class="faq-item">
       <summary>Does any audio or text leave my computer?</summary>
-      <p>No. Everything runs 100% on-device. Audio is recorded to a temporary file, transcribed locally by Whisper, and the file is immediately deleted. There are zero network requests — no cloud, no accounts, no telemetry.</p>
+      <p>No. Everything runs 100% on-device. Set <code>maxRecordings</code> to 0 for the original behavior: audio goes to a temp file, transcribed locally by Whisper, then deleted immediately. With <code>maxRecordings</code> &gt; 0 (default 10), recordings are stored in <code>~/.config/open-wispr/recordings/</code> for reprocessing; old ones are pruned automatically. There are zero network requests — no cloud, no accounts, no telemetry.</p>
     </details>
     <details class="faq-item">
       <summary>How does this compare to VoiceInk, Whisper Flow, or Superwhisper?</summary>

--- a/llms.txt
+++ b/llms.txt
@@ -8,7 +8,7 @@ open-wispr is a lightweight macOS app that provides push-to-talk voice dictation
 
 - **Price**: Free and open source (MIT license)
 - **Platform**: macOS (Apple Silicon and Intel)
-- **Privacy**: 100% on-device. Zero network requests. Audio is recorded to a temp file, transcribed locally, and immediately deleted.
+- **Privacy**: 100% on-device. Zero network requests. Set maxRecordings to 0 for temp file + immediate delete. With maxRecordings > 0, recordings stored in ~/.config/open-wispr/recordings/ for reprocessing; old ones pruned automatically.
 - **Install**: `brew install human37/open-wispr/open-wispr` or guided installer via `curl -fsSL https://open-wispr.pages.dev/install.sh | bash`
 - **Source**: https://github.com/human37/open-wispr
 - **Website**: https://open-wispr.pages.dev/


### PR DESCRIPTION
### Why I built this
I didn’t open an issue first as requested by the guidelines. I implemented this while using open-wispr. A transcription failed and I had to recover the recording before it was overwritten and manually transcribe it so I wouldn’t lose about 5 minutes of dictation. That’s why I added this feature: to keep recent recordings and allow re-transcription from the tray when something goes wrong.

### Summary
This PR adds persistent recording history and a way to re-transcribe past recordings from the tray menu. The changes were implemented with AI assistance and have been tested locally for about 2 days. I’m using this build daily and hope it can be merged.

Recent recordings:

<img width="418" height="290" alt="image" src="https://github.com/user-attachments/assets/2daee78d-6c18-46cf-aa4c-fb540a12f1c2" />

Icon changes when one of them is clicked and transcription is complete (and copied to clipboard):

<img width="40" height="23" alt="image" src="https://github.com/user-attachments/assets/572722a0-57ce-4b57-9abc-577ecb2f3659" />

### Features

- **Recording history** — Store up to 10 recordings (configurable via `maxRecordings`) in `~/.config/open-wispr/recordings/`
- **Recent Recordings submenu** — Click a recording to re-transcribe and copy the result to the clipboard
- **Privacy option** — Set `maxRecordings` to `0` to restore the original behavior (temp file, deleted immediately)
- **Visual feedback** — Checkmark icon and “Copied to clipboard” status when reprocess succeeds
- **Differentiation** — Numeric identifiers on menu items when recordings share the same minute

### Configuration

```json
{
  "maxRecordings": 10
}
```

- `0` — Original behavior: temp file, deleted after transcription  
- `1–100` — Keep recordings for reprocessing (default: 10)

### Backward compatibility

Existing configs work unchanged; `maxRecordings` defaults to 10 when omitted.

### Files changed

- **New:** `RecordingStore.swift` — Recording storage and pruning
- **Modified:** `Config.swift`, `AudioRecorder.swift`, `AppDelegate.swift`, `StatusBarController.swift`
- **Docs:** `README.md`, `index.html`, `llms.txt`, `CONTRIBUTING.md`