### PR TITLE
Fix simulated paste for non-QWERTY keyboard layouts

### DIFF
--- a/Sources/OpenWispr/TextInserter.swift
+++ b/Sources/OpenWispr/TextInserter.swift
@@ -1,5 +1,7 @@
 import AppKit
 import Foundation
+import Cocoa
+import Carbon.HIToolbox
 
 class TextInserter {
     func insert(text: String) {
@@ -40,14 +42,66 @@ class TextInserter {
     }
 
     private func simulatePaste() {
-        let source = CGEventSource(stateID: .hidSystemState)
+        guard let vKey = currentKeyCodeForCharacter("v") else {
+            return
+        }
 
-        let keyDown = CGEvent(keyboardEventSource: source, virtualKey: 0x09, keyDown: true)  // 'v'
-        keyDown?.flags = .maskCommand
-        keyDown?.post(tap: .cghidEventTap)
+        guard let source = CGEventSource(stateID: .hidSystemState),
+            let keyDown = CGEvent(keyboardEventSource: source, virtualKey: vKey, keyDown: true),
+            let keyUp = CGEvent(keyboardEventSource: source, virtualKey: vKey, keyDown: false) else {
+            return
+        }
 
-        let keyUp = CGEvent(keyboardEventSource: source, virtualKey: 0x09, keyDown: false)
-        keyUp?.flags = .maskCommand
-        keyUp?.post(tap: .cghidEventTap)
+        keyDown.flags = .maskCommand
+        keyUp.flags = .maskCommand
+
+        keyDown.post(tap: .cghidEventTap)
+        keyUp.post(tap: .cghidEventTap)
+    }
+
+    private func currentKeyCodeForCharacter(_ target: Character) -> CGKeyCode? {
+        guard let inputSource = TISCopyCurrentKeyboardLayoutInputSource()?.takeRetainedValue(),
+            let rawLayoutData = TISGetInputSourceProperty(inputSource, kTISPropertyUnicodeKeyLayoutData) else {
+            return nil
+        }
+
+        let layoutData = unsafeBitCast(rawLayoutData, to: CFData.self)
+        guard let layoutBytes = CFDataGetBytePtr(layoutData) else {
+            return nil
+        }
+
+        let keyboardLayout = UnsafePointer<UCKeyboardLayout>(OpaquePointer(layoutBytes))
+        let keyboardType = UInt32(LMGetKbdType())
+        let wanted = String(target).lowercased()
+
+        for keyCode in 0..<128 {
+            for modifierState: UInt32 in [0, UInt32(shiftKey >> 8)] {
+                var deadKeyState: UInt32 = 0
+                var chars = [UniChar](repeating: 0, count: 4)
+                var actualLength: Int = 0
+
+                let status = UCKeyTranslate(
+                    keyboardLayout,
+                    UInt16(keyCode),
+                    UInt16(kUCKeyActionDisplay),
+                    modifierState,
+                    keyboardType,
+                    OptionBits(kUCKeyTranslateNoDeadKeysBit),
+                    &deadKeyState,
+                    chars.count,
+                    &actualLength,
+                    &chars
+                )
+
+                guard status == noErr else { continue }
+
+                let produced = String(utf16CodeUnits: chars, count: actualLength).lowercased()
+                if produced == wanted {
+                    return CGKeyCode(keyCode)
+                }
+            }
+        }
+
+        return nil
     }
 }


### PR DESCRIPTION
## Description

This updates the simulated paste shortcut to resolve the V key from the currently active macOS keyboard layout instead of using a hardcoded QWERTY keycode.

Previously, paste was always sent using the physical US V key (0x09), which caused failures on layouts like Dvorak, AZERTY, and other non-QWERTY layouts. The new implementation looks up the correct keycode for v from the active input source before posting the ⌘ + V event.

This keeps the existing behavior for QWERTY users while fixing paste for users on alternative keyboard layouts.