### PR TITLE
Validate model files and surface errors to the user

### DIFF
--- a/Sources/OpenWisprLib/AppDelegate.swift
+++ b/Sources/OpenWisprLib/AppDelegate.swift
@@ -96,6 +96,19 @@ public class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
 
+        if let modelPath = Transcriber.findModel(modelSize: config.modelSize) {
+            let modelURL = URL(fileURLWithPath: modelPath)
+            if !ModelDownloader.isValidGGMLFile(at: modelURL) {
+                let msg = "Model file is corrupted. Re-download with: open-wispr download-model \(config.modelSize)"
+                print("Error: \(msg)")
+                DispatchQueue.main.async {
+                    self.statusBar.state = .error(msg)
+                    self.statusBar.buildMenu()
+                }
+                return
+            }
+        }
+
         DispatchQueue.main.async { [weak self] in
             self?.startListening()
         }
@@ -134,7 +147,8 @@ public class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applyConfigChange(_ newConfig: Config) {
         guard isReady else { return }
-        let wasDownloading = statusBar.state == .downloading
+        let wasDownloading: Bool
+        if case .downloading = statusBar.state { wasDownloading = true } else { wasDownloading = false }
         config = newConfig
         transcriber = Transcriber(modelSize: config.modelSize, language: config.language)
         transcriber.spokenPunctuation = config.spokenPunctuation?.value ?? false
@@ -262,15 +276,21 @@ public class AppDelegate: NSObject, NSApplicationDelegate {
                 }
                 DispatchQueue.main.async {
                     print("Error: \(error.localizedDescription)")
-                    self.statusBar.state = .idle
+                    self.statusBar.state = .error(error.localizedDescription)
                     self.statusBar.buildMenu()
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+                        if case .error = self.statusBar.state {
+                            self.statusBar.state = .idle
+                            self.statusBar.buildMenu()
+                        }
+                    }
                 }
             }
         }
     }
 
     public func reprocess(audioURL: URL) {
-        guard statusBar.state == .idle else { return }
+        guard case .idle = statusBar.state else { return }
 
         statusBar.state = .transcribing
 

--- a/Sources/OpenWisprLib/ModelDownloader.swift
+++ b/Sources/OpenWisprLib/ModelDownloader.swift
@@ -58,14 +58,36 @@ public class ModelDownloader: NSObject, URLSessionDownloadDelegate {
             return
         }
         do {
+            if let httpResponse = downloadTask.response as? HTTPURLResponse, httpResponse.statusCode != 200 {
+                completion?(ModelDownloadError.httpError(httpResponse.statusCode))
+                return
+            }
+
             if FileManager.default.fileExists(atPath: destPath.path) {
                 try FileManager.default.removeItem(at: destPath)
             }
             try FileManager.default.moveItem(at: location, to: destPath)
+
+            if !ModelDownloader.isValidGGMLFile(at: destPath) {
+                try? FileManager.default.removeItem(at: destPath)
+                completion?(ModelDownloadError.invalidModelData)
+                return
+            }
+
             completion?(nil)
         } catch {
             completion?(error)
         }
+    }
+
+    public static func isValidGGMLFile(at url: URL) -> Bool {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return false }
+        defer { handle.closeFile() }
+        guard let magic = try? handle.read(upToCount: 4), magic.count == 4 else { return false }
+        // GGML magic: 0x67676d6c ("ggml"), GGJT magic: 0x67676a74 ("ggjt"), GGUF magic: 0x46554747 ("GGUF")
+        let magicU32 = magic.withUnsafeBytes { $0.load(as: UInt32.self) }
+        let knownMagics: Set<UInt32> = [0x67676d6c, 0x67676a74, 0x46554747]
+        return knownMagics.contains(magicU32)
     }
 
     public func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didWriteData bytesWritten: Int64, totalBytesWritten: Int64, totalBytesExpectedToWrite: Int64) {
@@ -81,13 +103,19 @@ public class ModelDownloader: NSObject, URLSessionDownloadDelegate {
     }
 }
 
-enum ModelDownloadError: LocalizedError {
+public enum ModelDownloadError: LocalizedError {
     case downloadFailed
+    case httpError(Int)
+    case invalidModelData
 
-    var errorDescription: String? {
+    public var errorDescription: String? {
         switch self {
         case .downloadFailed:
             return "Failed to download model"
+        case .httpError(let statusCode):
+            return "Download failed with HTTP status \(statusCode). Check your network connection or proxy settings."
+        case .invalidModelData:
+            return "Downloaded file is not a valid GGML model (possibly a proxy error page). Check your network connection or try downloading from a different network."
         }
     }
 }

--- a/Sources/OpenWisprLib/StatusBarController.swift
+++ b/Sources/OpenWisprLib/StatusBarController.swift
@@ -27,6 +27,7 @@ class StatusBarController: NSObject {
         case downloading
         case waitingForPermission
         case copiedToClipboard
+        case error(String)
     }
 
     var state: State = .idle {
@@ -62,7 +63,7 @@ class StatusBarController: NSObject {
     func updateDownloadProgress(_ text: String?, percent: Double = 0) {
         downloadProgress = text
         downloadPercent = percent
-        if state == .downloading {
+        if case .downloading = state {
             setIcon(StatusBarController.drawDownloadProgress(downloadPercent))
         }
         if let text = text, let item = stateMenuItem {
@@ -106,9 +107,10 @@ class StatusBarController: NSObject {
             case .downloading: stateLabel = "Downloading model..."
             case .waitingForPermission: stateLabel = "Waiting for Accessibility permission..."
             case .copiedToClipboard: stateLabel = "Copied to clipboard"
+            case .error(let message): stateLabel = "Error: \(message)"
             }
         }
-        if state == .waitingForPermission {
+        if case .waitingForPermission = state {
             let target = MenuItemTarget {
                 Permissions.openAccessibilitySettings()
             }
@@ -315,6 +317,8 @@ class StatusBarController: NSObject {
             setIcon(StatusBarController.drawLockIcon())
         case .copiedToClipboard:
             setIcon(StatusBarController.drawCheckmarkIcon())
+        case .error:
+            setIcon(StatusBarController.drawWarningIcon())
         }
     }
 
@@ -582,6 +586,36 @@ class StatusBarController: NSObject {
             path.lineCapStyle = .round
             path.lineJoinStyle = .round
             path.stroke()
+
+            return true
+        }
+        image.isTemplate = true
+        return image
+    }
+
+    static func drawWarningIcon() -> NSImage {
+        let size = NSSize(width: 18, height: 18)
+        let image = NSImage(size: size, flipped: false) { rect in
+            NSColor.black.setStroke()
+            NSColor.black.setFill()
+
+            let centerX = rect.midX
+
+            // Triangle outline
+            let triangle = NSBezierPath()
+            triangle.move(to: NSPoint(x: centerX, y: 16))
+            triangle.line(to: NSPoint(x: centerX - 7, y: 3))
+            triangle.line(to: NSPoint(x: centerX + 7, y: 3))
+            triangle.close()
+            triangle.lineWidth = 1.5
+            triangle.lineJoinStyle = .round
+            triangle.stroke()
+
+            // Exclamation mark
+            let stemRect = NSRect(x: centerX - 0.75, y: 7, width: 1.5, height: 5)
+            NSBezierPath(roundedRect: stemRect, xRadius: 0.75, yRadius: 0.75).fill()
+            let dotRect = NSRect(x: centerX - 1, y: 4.5, width: 2, height: 2)
+            NSBezierPath(ovalIn: dotRect).fill()
 
             return true
         }


### PR DESCRIPTION
## Summary

- Validate GGML magic bytes after download to detect corrupt files (e.g. proxy error pages saved as model files)
- Check HTTP status code on download response
- Validate model integrity at startup before entering ready state
- Show transcription errors in the status bar (with warning icon) instead of only printing to stdout

Fixes #37

## Test plan

- [ ] Download a model on a network that blocks huggingface.co and verify the error message is shown
- [ ] Corrupt a model file manually (e.g. `echo "bad" > ~/.config/open-wispr/models/ggml-base.en.bin`) and restart - verify the error state appears
- [ ] Record with a valid model and verify normal flow still works
- [ ] Trigger a transcription error and verify the warning icon appears briefly in the status bar