### PR TITLE
Add audio input device selection

### DIFF
--- a/Sources/OpenWisprLib/AppDelegate.swift
+++ b/Sources/OpenWisprLib/AppDelegate.swift
@@ -31,6 +31,7 @@ public class AppDelegate: NSObject, NSApplicationDelegate {
     private func setupInner() throws {
         config = Config.load()
         inserter = TextInserter()
+        recorder.preferredDeviceID = config.audioInputDeviceID
         if Config.effectiveMaxRecordings(config.maxRecordings) == 0 {
             RecordingStore.deleteAllRecordings()
         }
@@ -150,6 +151,7 @@ public class AppDelegate: NSObject, NSApplicationDelegate {
         let wasDownloading: Bool
         if case .downloading = statusBar.state { wasDownloading = true } else { wasDownloading = false }
         config = newConfig
+        recorder.preferredDeviceID = config.audioInputDeviceID
         transcriber = Transcriber(modelSize: config.modelSize, language: config.language)
         transcriber.spokenPunctuation = config.spokenPunctuation?.value ?? false
         inserter = TextInserter()

--- a/Sources/OpenWisprLib/AudioDeviceManager.swift
+++ b/Sources/OpenWisprLib/AudioDeviceManager.swift
@@ -1,0 +1,94 @@
+import CoreAudio
+import Foundation
+
+struct AudioInputDevice {
+    let id: AudioDeviceID
+    let name: String
+    let isDefault: Bool
+}
+
+class AudioDeviceManager {
+    static func listInputDevices() -> [AudioInputDevice] {
+        let defaultID = getDefaultInputDeviceID()
+
+        var propertySize: UInt32 = 0
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDevices,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+
+        var status = AudioObjectGetPropertyDataSize(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address,
+            0, nil,
+            &propertySize
+        )
+        guard status == noErr else { return [] }
+
+        let deviceCount = Int(propertySize) / MemoryLayout<AudioDeviceID>.size
+        var deviceIDs = [AudioDeviceID](repeating: 0, count: deviceCount)
+        status = AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address,
+            0, nil,
+            &propertySize,
+            &deviceIDs
+        )
+        guard status == noErr else { return [] }
+
+        var result: [AudioInputDevice] = []
+        for deviceID in deviceIDs {
+            guard hasInputStreams(deviceID: deviceID),
+                  let name = getDeviceName(deviceID: deviceID) else { continue }
+            result.append(AudioInputDevice(
+                id: deviceID,
+                name: name,
+                isDefault: deviceID == defaultID
+            ))
+        }
+        return result
+    }
+
+    static func getDefaultInputDeviceID() -> AudioDeviceID {
+        var deviceID: AudioDeviceID = 0
+        var size = UInt32(MemoryLayout<AudioDeviceID>.size)
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultInputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address,
+            0, nil,
+            &size,
+            &deviceID
+        )
+        return deviceID
+    }
+
+    private static func hasInputStreams(deviceID: AudioDeviceID) -> Bool {
+        var size: UInt32 = 0
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyStreams,
+            mScope: kAudioObjectPropertyScopeInput,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        let status = AudioObjectGetPropertyDataSize(deviceID, &address, 0, nil, &size)
+        return status == noErr && size > 0
+    }
+
+    private static func getDeviceName(deviceID: AudioDeviceID) -> String? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioObjectPropertyName,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var name: Unmanaged<CFString>?
+        var size = UInt32(MemoryLayout<Unmanaged<CFString>?>.size)
+        let status = AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, &name)
+        guard status == noErr, let cfName = name?.takeRetainedValue() else { return nil }
+        return cfName as String
+    }
+}

--- a/Sources/OpenWisprLib/AudioDeviceManager.swift
+++ b/Sources/OpenWisprLib/AudioDeviceManager.swift
@@ -40,6 +40,7 @@ class AudioDeviceManager {
         var result: [AudioInputDevice] = []
         for deviceID in deviceIDs {
             guard hasInputStreams(deviceID: deviceID),
+                  !isVirtualDevice(deviceID: deviceID),
                   let name = getDeviceName(deviceID: deviceID) else { continue }
             result.append(AudioInputDevice(
                 id: deviceID,
@@ -66,6 +67,20 @@ class AudioDeviceManager {
             &deviceID
         )
         return deviceID
+    }
+
+    private static func isVirtualDevice(deviceID: AudioDeviceID) -> Bool {
+        var transportType: UInt32 = 0
+        var size = UInt32(MemoryLayout<UInt32>.size)
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyTransportType,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        let status = AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, &transportType)
+        guard status == noErr else { return false }
+        return transportType == kAudioDeviceTransportTypeAggregate
+            || transportType == kAudioDeviceTransportTypeVirtual
     }
 
     private static func hasInputStreams(deviceID: AudioDeviceID) -> Bool {

--- a/Sources/OpenWisprLib/AudioRecorder.swift
+++ b/Sources/OpenWisprLib/AudioRecorder.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import CoreAudio
 import Foundation
 
 class AudioRecorder {
@@ -6,11 +7,17 @@ class AudioRecorder {
     private var audioFile: AVAudioFile?
     private var isRecording = false
     private var currentOutputURL: URL?
+    var preferredDeviceID: AudioDeviceID?
 
     func startRecording(to outputURL: URL) throws {
         guard !isRecording else { return }
 
         let engine = AVAudioEngine()
+
+        if let deviceID = preferredDeviceID {
+            setInputDevice(deviceID, on: engine)
+        }
+
         let inputNode = engine.inputNode
         let format = inputNode.outputFormat(forBus: 0)
 
@@ -73,5 +80,25 @@ class AudioRecorder {
         isRecording = false
 
         return currentOutputURL
+    }
+
+    private func setInputDevice(_ deviceID: AudioDeviceID, on engine: AVAudioEngine) {
+        guard let audioUnit = engine.inputNode.audioUnit else {
+            print("Warning: could not access audio unit to set input device")
+            return
+        }
+
+        var devID = deviceID
+        let status = AudioUnitSetProperty(
+            audioUnit,
+            kAudioOutputUnitProperty_CurrentDevice,
+            kAudioUnitScope_Global,
+            0,
+            &devID,
+            UInt32(MemoryLayout<AudioDeviceID>.size)
+        )
+        if status != noErr {
+            print("Warning: failed to set audio input device (status: \(status))")
+        }
     }
 }

--- a/Sources/OpenWisprLib/Config.swift
+++ b/Sources/OpenWisprLib/Config.swift
@@ -13,6 +13,7 @@ public struct Config: Codable {
     public var spokenPunctuation: FlexBool?
     public var maxRecordings: Int?
     public var toggleMode: FlexBool?
+    public var audioInputDeviceID: UInt32?
 
     public static let supportedLanguages: [LanguageOption] = [
         LanguageOption(code: "auto", name: "Auto-Detect"),

--- a/Sources/OpenWisprLib/StatusBarController.swift
+++ b/Sources/OpenWisprLib/StatusBarController.swift
@@ -231,6 +231,7 @@ class StatusBarController: NSObject {
         }
         let audioItem = NSMenuItem(title: "Audio Input: \(currentDeviceName)", action: nil, keyEquivalent: "")
         let audioSubmenu = NSMenu()
+        audioSubmenu.autoenablesItems = false
 
         let defaultTarget = MenuItemTarget { [weak self] in
             var cfg = Config.load()

--- a/Sources/OpenWisprLib/StatusBarController.swift
+++ b/Sources/OpenWisprLib/StatusBarController.swift
@@ -220,6 +220,51 @@ class StatusBarController: NSObject {
         modelItem.submenu = modelSubmenu
         menu.addItem(modelItem)
 
+        let devices = AudioDeviceManager.listInputDevices()
+        let selectedDeviceID = config.audioInputDeviceID
+        let currentDeviceName: String
+        if let selectedID = selectedDeviceID,
+           let device = devices.first(where: { $0.id == selectedID }) {
+            currentDeviceName = device.name
+        } else {
+            currentDeviceName = "System Default"
+        }
+        let audioItem = NSMenuItem(title: "Audio Input: \(currentDeviceName)", action: nil, keyEquivalent: "")
+        let audioSubmenu = NSMenu()
+
+        let defaultTarget = MenuItemTarget { [weak self] in
+            var cfg = Config.load()
+            cfg.audioInputDeviceID = nil
+            try? cfg.save()
+            self?.onConfigChange?(cfg)
+        }
+        menuItemTargets.append(defaultTarget)
+        let defaultItem = NSMenuItem(title: "System Default", action: #selector(MenuItemTarget.invoke), keyEquivalent: "")
+        defaultItem.target = defaultTarget
+        if selectedDeviceID == nil { defaultItem.state = .on }
+        audioSubmenu.addItem(defaultItem)
+
+        if !devices.isEmpty {
+            audioSubmenu.addItem(NSMenuItem.separator())
+        }
+
+        for device in devices {
+            let target = MenuItemTarget { [weak self] in
+                var cfg = Config.load()
+                cfg.audioInputDeviceID = device.id
+                try? cfg.save()
+                self?.onConfigChange?(cfg)
+            }
+            menuItemTargets.append(target)
+            let item = NSMenuItem(title: device.name, action: #selector(MenuItemTarget.invoke), keyEquivalent: "")
+            item.target = target
+            if selectedDeviceID == device.id { item.state = .on }
+            audioSubmenu.addItem(item)
+        }
+
+        audioItem.submenu = audioSubmenu
+        menu.addItem(audioItem)
+
         menu.addItem(NSMenuItem.separator())
 
         let toggleTarget = MenuItemTarget { [weak self] in

--- a/Sources/OpenWisprLib/Version.swift
+++ b/Sources/OpenWisprLib/Version.swift
@@ -1,3 +1,3 @@
 public enum OpenWispr {
-    public static let version = "0.33.0"
+    public static let version = "0.34.0"
 }


### PR DESCRIPTION
## Summary

Closes #45

- Adds an "Audio Input" submenu to the menu bar, listing all available input devices from CoreAudio
- "System Default" option uses whatever macOS has selected (previous behavior)
- Selecting a specific device sets it on the AVAudioEngine's input node via `kAudioOutputUnitProperty_CurrentDevice` before each recording session
- Selection persists in `config.json` as `audioInputDeviceID`

This prevents the Bluetooth profile-switching issue described in #45 by letting users explicitly select their built-in microphone (or any other input) instead of relying on the system default which may be their AirPods.

## Test plan

- [ ] Verify "Audio Input" submenu appears in menu bar between Model and Toggle Mode
- [ ] Verify all connected input devices are listed
- [ ] Verify selecting a device persists across app restarts (check `~/.config/open-wispr/config.json`)
- [ ] Verify recording works with a non-default device selected
- [ ] Verify "System Default" reverts to previous behavior
- [ ] Verify with Bluetooth headphones connected: selecting built-in mic avoids the profile-switching issue