### PR TITLE
Rename the missing large model to large-v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Larger models are more accurate but slower and use more memory. The default `bas
 | `small.en` | 466 MB | Moderate | Better | Longer dictation, technical terms |
 | `medium.en` | 1.5 GB | Slower | Great | Maximum accuracy, complex speech |
 | `large-v3-turbo` | 1.6 GB | Moderate | Great | Fast multilingual, near-large accuracy |
-| `large` | 3 GB | Slowest | Best | Multilingual, highest accuracy (M1 Pro+ recommended) |
+| `large-v3` | 3 GB | Slowest | Best | Multilingual, highest accuracy (M1 Pro+ recommended) |
 
 > **Non-English languages:** Models ending in `.en` are English-only. To use another language, switch to the equivalent model without the `.en` suffix (e.g. `base.en` → `base`) and set the `language` field to your language code. Multilingual models are slightly less accurate for English but support 99 languages.
 

--- a/Sources/OpenWisprLib/Config.swift
+++ b/Sources/OpenWisprLib/Config.swift
@@ -123,7 +123,7 @@ public struct Config: Codable {
         "base.en", "base",
         "small.en", "small",
         "medium.en", "medium",
-        "large-v3-turbo", "large",
+        "large-v3-turbo", "large-v3",
     ]
 
     public static let defaultMaxRecordings = 0

--- a/Sources/OpenWisprLib/Version.swift
+++ b/Sources/OpenWisprLib/Version.swift
@@ -1,3 +1,3 @@
 public enum OpenWispr {
-    public static let version = "0.34.0"
+    public static let version = "0.35.0"
 }

--- a/Tests/OpenWisprTests/ModelAvailabilityTests.swift
+++ b/Tests/OpenWisprTests/ModelAvailabilityTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import OpenWisprLib
+
+final class ModelAvailabilityTests: XCTestCase {
+
+    func testAllSupportedModelURLsAreReachable() async throws {
+        for model in Config.supportedModels {
+            let urlString = "\(ModelDownloader.baseURL)/ggml-\(model).bin"
+            let url = try XCTUnwrap(URL(string: urlString), "Invalid URL for model '\(model)'")
+
+            var request = URLRequest(url: url)
+            request.httpMethod = "HEAD"
+
+            let (_, response) = try await URLSession.shared.data(for: request)
+            let httpResponse = try XCTUnwrap(response as? HTTPURLResponse)
+            XCTAssertEqual(
+                httpResponse.statusCode, 200,
+                "Model '\(model)' returned \(httpResponse.statusCode) at \(urlString)"
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- replace the missing  model name with  in the supported model list
- update the README model table to match the actual whisper.cpp artifact name

Fixes #52.