### PR TITLE
Migrate modelSize: large to large-v3 (fixes #55)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,21 @@ Larger models are more accurate but slower and use more memory. The default `bas
 | Model | Size | Speed | Accuracy | Best for |
 |---|---|---|---|---|
 | `tiny.en` | 75 MB | Fastest | Lower | Quick notes, short phrases |
+| `tiny.en-q5_1` | 31 MB | Fastest | Lower | Same as `tiny.en`, smallest download |
 | **`base.en`** | 142 MB | **Fast** | **Good** | **Most users (default)** |
+| `base.en-q5_1` | 57 MB | Fast | Good | Same as `base.en`, smaller download |
 | `small.en` | 466 MB | Moderate | Better | Longer dictation, technical terms |
+| `small.en-q5_1` | 181 MB | Moderate | Better | Same as `small.en`, smaller download |
 | `medium.en` | 1.5 GB | Slower | Great | Maximum accuracy, complex speech |
+| `medium.en-q5_0` | 514 MB | Slower | Great | Same as `medium.en`, smaller download |
 | `large-v3-turbo` | 1.6 GB | Moderate | Great | Fast multilingual, near-large accuracy |
+| `large-v3-turbo-q8_0` | 834 MB | Moderate | Great | Same as `large-v3-turbo`, smaller download |
+| `large-v3-turbo-q5_0` | 547 MB | Moderate | Great | Lightest large-tier model with near-full quality |
 | `large-v3` | 3 GB | Slowest | Best | Multilingual, highest accuracy (M1 Pro+ recommended) |
 
-> **Non-English languages:** Models ending in `.en` are English-only. To use another language, switch to the equivalent model without the `.en` suffix (e.g. `base.en` → `base`) and set the `language` field to your language code. Multilingual models are slightly less accurate for English but support 99 languages.
+> **Quantized variants (`-q5_0`, `-q5_1`, `-q8_0`):** Same architecture and weights as the full model, compressed with integer quantization to roughly a third of the original disk and memory footprint. `q8_0` is the most conservative (smallest quality loss, larger file); `q5_1` and `q5_0` trade a bit more quality for substantially smaller downloads. For dictation the difference is usually imperceptible.
+
+> **Non-English languages:** Models ending in `.en` (including the `.en-q…` quantized variants) are English-only. To use another language, switch to the equivalent multilingual model (e.g. `base.en` → `base`, or `large-v3-turbo` for the fastest large-tier option) and set the `language` field to your language code. Multilingual models are slightly less accurate for English but support 99 languages.
 
 If the Globe key opens the emoji picker: **System Settings → Keyboard → "Press 🌐 key to" → "Do Nothing"**
 

--- a/Sources/OpenWisprLib/Config.swift
+++ b/Sources/OpenWisprLib/Config.swift
@@ -126,6 +126,14 @@ public struct Config: Codable {
         "large-v3-turbo", "large-v3",
     ]
 
+    public static let modelAliases: [String: String] = [
+        "large": "large-v3",
+    ]
+
+    public static func resolveModelAlias(_ size: String) -> String {
+        return modelAliases[size] ?? size
+    }
+
     public static let defaultMaxRecordings = 0
 
     public static func effectiveMaxRecordings(_ value: Int?) -> Int {
@@ -161,7 +169,13 @@ public struct Config: Codable {
         }
 
         do {
-            return try JSONDecoder().decode(Config.self, from: data)
+            var config = try JSONDecoder().decode(Config.self, from: data)
+            let resolved = Config.resolveModelAlias(config.modelSize)
+            if resolved != config.modelSize {
+                config.modelSize = resolved
+                try? config.save()
+            }
+            return config
         } catch {
             fputs("Warning: unable to parse \(configFile.path): \(error.localizedDescription)\n", stderr)
             return Config.defaultConfig
@@ -169,7 +183,9 @@ public struct Config: Codable {
     }
 
     public static func decode(from data: Data) throws -> Config {
-        return try JSONDecoder().decode(Config.self, from: data)
+        var config = try JSONDecoder().decode(Config.self, from: data)
+        config.modelSize = Config.resolveModelAlias(config.modelSize)
+        return config
     }
 
     public func save() throws {

--- a/Sources/OpenWisprLib/Config.swift
+++ b/Sources/OpenWisprLib/Config.swift
@@ -119,11 +119,16 @@ public struct Config: Codable {
     ]
 
     public static let supportedModels: [String] = [
-        "tiny.en", "tiny",
-        "base.en", "base",
-        "small.en", "small",
-        "medium.en", "medium",
-        "large-v3-turbo", "large-v3",
+        "tiny.en", "tiny.en-q5_1",
+        "tiny",
+        "base.en", "base.en-q5_1",
+        "base",
+        "small.en", "small.en-q5_1",
+        "small",
+        "medium.en", "medium.en-q5_0",
+        "medium",
+        "large-v3-turbo", "large-v3-turbo-q8_0", "large-v3-turbo-q5_0",
+        "large-v3",
     ]
 
     public static let modelAliases: [String: String] = [
@@ -132,6 +137,10 @@ public struct Config: Codable {
 
     public static func resolveModelAlias(_ size: String) -> String {
         return modelAliases[size] ?? size
+    }
+
+    public static func isEnglishOnlyModel(_ name: String) -> Bool {
+        return name.hasSuffix(".en") || name.contains(".en-")
     }
 
     public static let defaultMaxRecordings = 0

--- a/Sources/OpenWisprLib/StatusBarController.swift
+++ b/Sources/OpenWisprLib/StatusBarController.swift
@@ -169,8 +169,8 @@ class StatusBarController: NSObject {
         let modelItem = NSMenuItem(title: "Model: \(config.modelSize)", action: nil, keyEquivalent: "")
         let modelSubmenu = NSMenu()
 
-        let englishModels = Config.supportedModels.filter { $0.hasSuffix(".en") }
-        let multilingualModels = Config.supportedModels.filter { !$0.hasSuffix(".en") }
+        let englishModels = Config.supportedModels.filter { Config.isEnglishOnlyModel($0) }
+        let multilingualModels = Config.supportedModels.filter { !Config.isEnglishOnlyModel($0) }
 
         let engHeader = NSMenuItem(title: "English", action: nil, keyEquivalent: "")
         engHeader.isEnabled = false

--- a/Sources/OpenWisprLib/Version.swift
+++ b/Sources/OpenWisprLib/Version.swift
@@ -1,3 +1,3 @@
 public enum OpenWispr {
-    public static let version = "0.35.0"
+    public static let version = "0.36.0"
 }

--- a/Tests/OpenWisprTests/ConfigTests.swift
+++ b/Tests/OpenWisprTests/ConfigTests.swift
@@ -168,6 +168,33 @@ final class ConfigTests: XCTestCase {
         }
     }
 
+    func testIsEnglishOnlyModelMatchesEnSuffix() {
+        XCTAssertTrue(Config.isEnglishOnlyModel("base.en"))
+        XCTAssertTrue(Config.isEnglishOnlyModel("medium.en"))
+    }
+
+    func testIsEnglishOnlyModelMatchesQuantizedEn() {
+        XCTAssertTrue(Config.isEnglishOnlyModel("tiny.en-q5_1"))
+        XCTAssertTrue(Config.isEnglishOnlyModel("medium.en-q5_0"))
+    }
+
+    func testIsEnglishOnlyModelRejectsMultilingual() {
+        XCTAssertFalse(Config.isEnglishOnlyModel("base"))
+        XCTAssertFalse(Config.isEnglishOnlyModel("large-v3"))
+        XCTAssertFalse(Config.isEnglishOnlyModel("large-v3-turbo"))
+        XCTAssertFalse(Config.isEnglishOnlyModel("large-v3-turbo-q5_0"))
+    }
+
+    func testEveryEnglishModelHasMultilingualPeer() {
+        // Sanity: each English model should be a recognised English variant
+        // and each multilingual model should not.
+        let english = Config.supportedModels.filter { Config.isEnglishOnlyModel($0) }
+        let multilingual = Config.supportedModels.filter { !Config.isEnglishOnlyModel($0) }
+        XCTAssertFalse(english.isEmpty)
+        XCTAssertFalse(multilingual.isEmpty)
+        XCTAssertEqual(english.count + multilingual.count, Config.supportedModels.count)
+    }
+
     func testConfigDecodeResolvesLargeAlias() throws {
         let json = """
         {

--- a/Tests/OpenWisprTests/ConfigTests.swift
+++ b/Tests/OpenWisprTests/ConfigTests.swift
@@ -147,6 +147,39 @@ final class ConfigTests: XCTestCase {
         XCTAssertTrue(Config.supportedModels.contains("base.en"))
     }
 
+    // MARK: - Model alias resolution
+
+    func testResolveModelAliasMapsLargeToLargeV3() {
+        XCTAssertEqual(Config.resolveModelAlias("large"), "large-v3")
+    }
+
+    func testResolveModelAliasReturnsInputForNonAliased() {
+        XCTAssertEqual(Config.resolveModelAlias("base.en"), "base.en")
+        XCTAssertEqual(Config.resolveModelAlias("large-v3"), "large-v3")
+        XCTAssertEqual(Config.resolveModelAlias("nonexistent"), "nonexistent")
+    }
+
+    func testModelAliasDestinationsAreSupported() {
+        for canonical in Config.modelAliases.values {
+            XCTAssertTrue(
+                Config.supportedModels.contains(canonical),
+                "Alias destination '\(canonical)' must be in Config.supportedModels"
+            )
+        }
+    }
+
+    func testConfigDecodeResolvesLargeAlias() throws {
+        let json = """
+        {
+            "hotkey": {"keyCode": 63, "modifiers": []},
+            "modelSize": "large",
+            "language": "en"
+        }
+        """.data(using: .utf8)!
+        let config = try Config.decode(from: json)
+        XCTAssertEqual(config.modelSize, "large-v3")
+    }
+
     func testConfigDecodesLanguageAuto() throws {
         let json = """
         {


### PR DESCRIPTION
## Summary

Closes #55. Existing configs with `"modelSize": "large"` (and hand-edited ones, as in the issue) still 404 against `ggml-large.bin` because PR #53 removed `large` from `supportedModels` without migrating persisted configs.

Adds `Config.modelAliases` (`"large"` → `"large-v3"`), resolves it in both `Config.decode(from:)` and `Config.load()`, and rewrites the on-disk config when an alias is applied so the migration is sticky.

## Test plan

- [x] `swift build` and `swift build -c release` succeed
- [ ] CI runs new `ConfigTests` (`testResolveModelAliasMapsLargeToLargeV3`, `testResolveModelAliasReturnsInputForNonAliased`, `testModelAliasDestinationsAreSupported`, `testConfigDecodeResolvesLargeAlias`) — couldn't run locally (CommandLineTools-only, no XCTest)
- [ ] Set `"modelSize": "large"` in `~/.config/open-wispr/config.json`, restart, verify `ggml-large-v3.bin` downloads and the file is rewritten with `"modelSize": "large-v3"`