### PR TITLE
Clarify quantized model tradeoffs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,22 +65,28 @@ Then restart: `brew services restart open-wispr`
 
 Larger models are more accurate but slower and use more memory. The default `base.en` is a good balance for most users.
 
-| Model | Size | Speed | Accuracy | Best for |
+| Model | Size | Speed | Accuracy | Notes |
 |---|---|---|---|---|
 | `tiny.en` | 75 MB | Fastest | Lower | Quick notes, short phrases |
-| `tiny.en-q5_1` | 31 MB | Fastest | Lower | Same as `tiny.en`, smallest download |
+| `tiny.en-q5_1` | 31 MB | Fastest | Lower | Quantized `tiny.en` (5-bit) — ~⅓ disk/RAM, slight quality loss |
 | **`base.en`** | 142 MB | **Fast** | **Good** | **Most users (default)** |
-| `base.en-q5_1` | 57 MB | Fast | Good | Same as `base.en`, smaller download |
+| `base.en-q5_1` | 57 MB | Fast | Good | Quantized `base.en` (5-bit) — ~⅓ disk/RAM, slight quality loss |
 | `small.en` | 466 MB | Moderate | Better | Longer dictation, technical terms |
-| `small.en-q5_1` | 181 MB | Moderate | Better | Same as `small.en`, smaller download |
+| `small.en-q5_1` | 181 MB | Moderate | Better | Quantized `small.en` (5-bit) — ~⅓ disk/RAM, slight quality loss |
 | `medium.en` | 1.5 GB | Slower | Great | Maximum accuracy, complex speech |
-| `medium.en-q5_0` | 514 MB | Slower | Great | Same as `medium.en`, smaller download |
+| `medium.en-q5_0` | 514 MB | Slower | Great | Quantized `medium.en` (5-bit) — ~⅓ disk/RAM, slight quality loss |
 | `large-v3-turbo` | 1.6 GB | Moderate | Great | Fast multilingual, near-large accuracy |
-| `large-v3-turbo-q8_0` | 834 MB | Moderate | Great | Same as `large-v3-turbo`, smaller download |
-| `large-v3-turbo-q5_0` | 547 MB | Moderate | Great | Lightest large-tier model with near-full quality |
+| `large-v3-turbo-q8_0` | 834 MB | Moderate | Great | Quantized `large-v3-turbo` (8-bit) — ~½ disk/RAM, near-zero quality loss |
+| `large-v3-turbo-q5_0` | 547 MB | Moderate | Great-ish | Quantized `large-v3-turbo` (5-bit) — ~⅓ disk/RAM, slight quality loss |
 | `large-v3` | 3 GB | Slowest | Best | Multilingual, highest accuracy (M1 Pro+ recommended) |
 
-> **Quantized variants (`-q5_0`, `-q5_1`, `-q8_0`):** Same architecture and weights as the full model, compressed with integer quantization to roughly a third of the original disk and memory footprint. `q8_0` is the most conservative (smallest quality loss, larger file); `q5_1` and `q5_0` trade a bit more quality for substantially smaller downloads. For dictation the difference is usually imperceptible.
+> **Quantized variants (`-q5_0`, `-q5_1`, `-q8_0`):** These are not separate models — they're the full model's weights compressed with integer quantization. The compute path is identical, so transcription speed is roughly the same as the corresponding full model, but disk and resident memory drop substantially.
+>
+> The number after `q` is the bit width per weight: lower = smaller file, more quality loss.
+> - **`q8_0`** (8-bit) — most conservative. ~½ the size of the full model. Quality loss is barely measurable; safe default if you want a smaller download without thinking about it.
+> - **`q5_1`** / **`q5_0`** (5-bit) — more aggressive. ~⅓ the size of the full model. Quality cost is small but real; you may notice it on edge cases (proper nouns, accents, ambient noise, long uninterrupted speech). `q5_1` is slightly higher quality than `q5_0`; whisper.cpp ships `q5_1` for the smaller English models and `q5_0` for `medium.en` and the large-tier models.
+>
+> For everyday dictation the difference between a quantized model and its full counterpart is usually imperceptible. If you start noticing misrecognitions on a quantized variant that don't happen on the full version, switch up — the trade-off isn't worth it for your workload.
 
 > **Non-English languages:** Models ending in `.en` (including the `.en-q…` quantized variants) are English-only. To use another language, switch to the equivalent multilingual model (e.g. `base.en` → `base`, or `large-v3-turbo` for the fastest large-tier option) and set the `language` field to your language code. Multilingual models are slightly less accurate for English but support 99 languages.
 

--- a/docs/install-guide.md
+++ b/docs/install-guide.md
@@ -132,8 +132,22 @@ The multilingual model will be downloaded automatically on next use.
 | base | `base.en` | `base` | ~142 MB |
 | small | `small.en` | `small` | ~466 MB |
 | medium | `medium.en` | `medium` | ~1.5 GB |
+| large (turbo) | — | `large-v3-turbo` | ~1.6 GB |
+| large (v3) | — | `large-v3` | ~3 GB |
 
-Larger models are more accurate but slower. `base` is a good starting point for most languages.
+Larger models are more accurate but slower. `base` is a good starting point for most languages. There is no English-only large model upstream — pick `large-v3-turbo` for the fastest large-tier option (multilingual, near-large quality).
+
+#### Quantized variants
+
+Each model above has one or more quantized variants on disk: same weights compressed to ~⅓–½ the size with minimal quality loss. Speed is unchanged because the compute path is identical.
+
+| Variant | Bit width | Size impact | Quality |
+|---|---|---|---|
+| `…-q8_0` (e.g. `large-v3-turbo-q8_0`) | 8-bit | ~½ the full model | Near-identical |
+| `…-q5_1` (e.g. `base.en-q5_1`) | 5-bit | ~⅓ the full model | Slight loss on edge cases |
+| `…-q5_0` (e.g. `medium.en-q5_0`, `large-v3-turbo-q5_0`) | 5-bit | ~⅓ the full model | Slight loss on edge cases |
+
+Whisper.cpp ships `q5_1` for the smaller English models (`tiny.en`, `base.en`, `small.en`) and `q5_0` for `medium.en` and the large-tier models. See the [README model table](https://github.com/human37/open-wispr#models) for the full list with sizes.
 
 ### Common language codes
 

--- a/index.html
+++ b/index.html
@@ -858,7 +858,7 @@
     <tr>
       <td>modelSize</td>
       <td>"base.en"</td>
-      <td><code>tiny.en</code> 75 MB, fastest &middot; <code>base.en</code> 142 MB, good balance (default) &middot; <code>small.en</code> 466 MB, more accurate &middot; <code>medium.en</code> 1.5 GB, great accuracy &middot; <code>large</code> 3 GB, best accuracy (M1 Pro+ recommended). Larger = more accurate but slower.</td>
+      <td><code>tiny.en</code> 75 MB, fastest &middot; <code>base.en</code> 142 MB, good balance (default) &middot; <code>small.en</code> 466 MB, more accurate &middot; <code>medium.en</code> 1.5 GB, great accuracy &middot; <code>large-v3-turbo</code> 1.6 GB, fast multilingual &middot; <code>large-v3</code> 3 GB, best accuracy (M1 Pro+ recommended). Quantized <code>-q5_0</code>/<code>-q5_1</code>/<code>-q8_0</code> variants are also available at ~⅓&ndash;½ the size with minimal quality loss &mdash; see the README for the full table.</td>
     </tr>
     <tr>
       <td>language</td>


### PR DESCRIPTION
## Summary

Follow-up to #56. Each quantized row now states it's quantized + bit width + size impact, instead of "same as X, smaller download". The explainer paragraph spells out the actual tradeoffs:

- compute path is identical, so speed matches the full model
- `q8_0` is conservative (~½ size, near-zero quality loss)
- `q5_1` / `q5_0` are more aggressive (~⅓ size, small but real quality cost on edge cases)
- guidance on when to switch back up to the full model

Renamed the table's last column from "Best for" to "Notes" since it now mixes use-cases (full models) with technical descriptions (quantized variants).

## Test plan

- [x] Docs-only — no code changes, no behavioural impact
- [ ] Skim rendered README on the PR page