### PR TITLE
Extract model details into MODELS.md

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -1,0 +1,41 @@
+# Models
+
+Complete reference for the Whisper models open-wispr supports. For a quick overview see the [README](README.md#models).
+
+## All supported models
+
+| Model | Size | Speed | Accuracy | Notes |
+|---|---|---|---|---|
+| `tiny.en` | 75 MB | Fastest | Lower | Quick notes, short phrases |
+| `tiny.en-q5_1` | 31 MB | Fastest | Lower | Quantized `tiny.en` (5-bit) — ~⅓ disk/RAM, slight quality loss |
+| **`base.en`** | 142 MB | **Fast** | **Good** | **Most users (default)** |
+| `base.en-q5_1` | 57 MB | Fast | Good | Quantized `base.en` (5-bit) — ~⅓ disk/RAM, slight quality loss |
+| `small.en` | 466 MB | Moderate | Better | Longer dictation, technical terms |
+| `small.en-q5_1` | 181 MB | Moderate | Better | Quantized `small.en` (5-bit) — ~⅓ disk/RAM, slight quality loss |
+| `medium.en` | 1.5 GB | Slower | Great | Maximum accuracy, complex speech |
+| `medium.en-q5_0` | 514 MB | Slower | Great | Quantized `medium.en` (5-bit) — ~⅓ disk/RAM, slight quality loss |
+| `large-v3-turbo` | 1.6 GB | Moderate | Great | Fast multilingual, near-large accuracy |
+| `large-v3-turbo-q8_0` | 834 MB | Moderate | Great | Quantized `large-v3-turbo` (8-bit) — ~½ disk/RAM, near-zero quality loss |
+| `large-v3-turbo-q5_0` | 547 MB | Moderate | Great-ish | Quantized `large-v3-turbo` (5-bit) — ~⅓ disk/RAM, slight quality loss |
+| `large-v3` | 3 GB | Slowest | Best | Multilingual, highest accuracy (M1 Pro+ recommended) |
+
+## Quantized variants
+
+The `-q5_0`, `-q5_1`, and `-q8_0` rows are not separate models — they're the full model's weights compressed with integer quantization. The compute path is identical, so transcription speed is roughly the same as the corresponding full model, but disk and resident memory drop substantially.
+
+The number after `q` is the bit width per weight: lower = smaller file, more quality loss.
+
+- **`q8_0`** (8-bit) — most conservative. ~½ the size of the full model. Quality loss is barely measurable; safe default if you want a smaller download without thinking about it.
+- **`q5_1`** / **`q5_0`** (5-bit) — more aggressive. ~⅓ the size of the full model. Quality cost is small but real; you may notice it on edge cases (proper nouns, accents, ambient noise, long uninterrupted speech). `q5_1` is slightly higher quality than `q5_0`; whisper.cpp ships `q5_1` for the smaller English models and `q5_0` for `medium.en` and the large-tier models.
+
+For everyday dictation the difference between a quantized model and its full counterpart is usually imperceptible. If you start noticing misrecognitions on a quantized variant that don't happen on the full version, switch up — the trade-off isn't worth it for your workload.
+
+## English vs. multilingual
+
+Models ending in `.en` (including the `.en-q…` quantized variants) are English-only. There is no English-only large model upstream — OpenAI never released one, so pick `large-v3-turbo` for the fastest large-tier multilingual option.
+
+To use another language, switch to the equivalent multilingual model (e.g. `base.en` → `base`, or `large-v3-turbo` for the fastest large-tier option) and set the `language` field in `~/.config/open-wispr/config.json` to your [ISO 639-1 code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes). Multilingual models are slightly less accurate for English but support 99 languages.
+
+## Where these come from
+
+Models are downloaded on demand from [`ggerganov/whisper.cpp`](https://huggingface.co/ggerganov/whisper.cpp/tree/main) on HuggingFace and cached in `~/.config/open-wispr/models/`.

--- a/README.md
+++ b/README.md
@@ -65,30 +65,18 @@ Then restart: `brew services restart open-wispr`
 
 Larger models are more accurate but slower and use more memory. The default `base.en` is a good balance for most users.
 
-| Model | Size | Speed | Accuracy | Notes |
+| Model | Size | Speed | Accuracy | Best for |
 |---|---|---|---|---|
 | `tiny.en` | 75 MB | Fastest | Lower | Quick notes, short phrases |
-| `tiny.en-q5_1` | 31 MB | Fastest | Lower | Quantized `tiny.en` (5-bit) — ~⅓ disk/RAM, slight quality loss |
 | **`base.en`** | 142 MB | **Fast** | **Good** | **Most users (default)** |
-| `base.en-q5_1` | 57 MB | Fast | Good | Quantized `base.en` (5-bit) — ~⅓ disk/RAM, slight quality loss |
 | `small.en` | 466 MB | Moderate | Better | Longer dictation, technical terms |
-| `small.en-q5_1` | 181 MB | Moderate | Better | Quantized `small.en` (5-bit) — ~⅓ disk/RAM, slight quality loss |
 | `medium.en` | 1.5 GB | Slower | Great | Maximum accuracy, complex speech |
-| `medium.en-q5_0` | 514 MB | Slower | Great | Quantized `medium.en` (5-bit) — ~⅓ disk/RAM, slight quality loss |
 | `large-v3-turbo` | 1.6 GB | Moderate | Great | Fast multilingual, near-large accuracy |
-| `large-v3-turbo-q8_0` | 834 MB | Moderate | Great | Quantized `large-v3-turbo` (8-bit) — ~½ disk/RAM, near-zero quality loss |
-| `large-v3-turbo-q5_0` | 547 MB | Moderate | Great-ish | Quantized `large-v3-turbo` (5-bit) — ~⅓ disk/RAM, slight quality loss |
 | `large-v3` | 3 GB | Slowest | Best | Multilingual, highest accuracy (M1 Pro+ recommended) |
 
-> **Quantized variants (`-q5_0`, `-q5_1`, `-q8_0`):** These are not separate models — they're the full model's weights compressed with integer quantization. The compute path is identical, so transcription speed is roughly the same as the corresponding full model, but disk and resident memory drop substantially.
->
-> The number after `q` is the bit width per weight: lower = smaller file, more quality loss.
-> - **`q8_0`** (8-bit) — most conservative. ~½ the size of the full model. Quality loss is barely measurable; safe default if you want a smaller download without thinking about it.
-> - **`q5_1`** / **`q5_0`** (5-bit) — more aggressive. ~⅓ the size of the full model. Quality cost is small but real; you may notice it on edge cases (proper nouns, accents, ambient noise, long uninterrupted speech). `q5_1` is slightly higher quality than `q5_0`; whisper.cpp ships `q5_1` for the smaller English models and `q5_0` for `medium.en` and the large-tier models.
->
-> For everyday dictation the difference between a quantized model and its full counterpart is usually imperceptible. If you start noticing misrecognitions on a quantized variant that don't happen on the full version, switch up — the trade-off isn't worth it for your workload.
+Each model also has quantized `-q5_0` / `-q5_1` / `-q8_0` variants at ~⅓–½ the disk and RAM with minimal quality loss. See **[MODELS.md](MODELS.md)** for the complete list and tradeoffs.
 
-> **Non-English languages:** Models ending in `.en` (including the `.en-q…` quantized variants) are English-only. To use another language, switch to the equivalent multilingual model (e.g. `base.en` → `base`, or `large-v3-turbo` for the fastest large-tier option) and set the `language` field to your language code. Multilingual models are slightly less accurate for English but support 99 languages.
+> **Non-English languages:** Models ending in `.en` are English-only. To use another language, switch to the equivalent multilingual model (e.g. `base.en` → `base`, or `large-v3-turbo` for the fastest large-tier option) and set the `language` field to your language code. Multilingual models are slightly less accurate for English but support 99 languages.
 
 If the Globe key opens the emoji picker: **System Settings → Keyboard → "Press 🌐 key to" → "Do Nothing"**
 

--- a/docs/install-guide.md
+++ b/docs/install-guide.md
@@ -137,17 +137,7 @@ The multilingual model will be downloaded automatically on next use.
 
 Larger models are more accurate but slower. `base` is a good starting point for most languages. There is no English-only large model upstream — pick `large-v3-turbo` for the fastest large-tier option (multilingual, near-large quality).
 
-#### Quantized variants
-
-Each model above has one or more quantized variants on disk: same weights compressed to ~⅓–½ the size with minimal quality loss. Speed is unchanged because the compute path is identical.
-
-| Variant | Bit width | Size impact | Quality |
-|---|---|---|---|
-| `…-q8_0` (e.g. `large-v3-turbo-q8_0`) | 8-bit | ~½ the full model | Near-identical |
-| `…-q5_1` (e.g. `base.en-q5_1`) | 5-bit | ~⅓ the full model | Slight loss on edge cases |
-| `…-q5_0` (e.g. `medium.en-q5_0`, `large-v3-turbo-q5_0`) | 5-bit | ~⅓ the full model | Slight loss on edge cases |
-
-Whisper.cpp ships `q5_1` for the smaller English models (`tiny.en`, `base.en`, `small.en`) and `q5_0` for `medium.en` and the large-tier models. See the [README model table](https://github.com/human37/open-wispr#models) for the full list with sizes.
+Each model also has quantized variants at ~⅓–½ the size with minimal quality loss. See [MODELS.md](https://github.com/human37/open-wispr/blob/main/MODELS.md) for the complete list and tradeoffs.
 
 ### Common language codes
 


### PR DESCRIPTION
## Summary

Docs-only refactor. The model section had grown a 12-row table plus a multi-paragraph quantized-variants explainer plus an English-vs-multilingual note in two places (README and install-guide).

- New `MODELS.md` holds the full 12-row table, quantization deep-dive, upstream source pointer, and language guidance.
- `README.md` keeps a 6-row table of just the full models plus a one-line pointer to `MODELS.md`. Language note kept inline.
- `docs/install-guide.md` drops its duplicate quantized subsection and links to `MODELS.md`.

## Test plan

- [x] Docs-only — no code changes
- [ ] Skim rendered Markdown on the PR page