### PR TITLE
Multiple hotkeys, app-bundle relaunch, CLI/Finder fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,23 @@ Edit `~/.config/open-wispr/config.json`:
 
 Then restart: `brew services restart open-wispr`
 
+To bind multiple hotkeys, use the `hotkeys` array instead:
+
+```json
+{
+  "hotkeys": [
+    { "keyCode": 63, "modifiers": [] },
+    { "keyCode": 96, "modifiers": [] }
+  ]
+}
+```
+
+Both `hotkey` (single) and `hotkeys` (array) are supported. If both are present, `hotkeys` takes precedence.
+
 | Option | Default | Values |
 |---|---|---|
 | **hotkey** | `63` | Globe (`63`), Right Option (`61`), F5 (`96`), or any key code |
+| **hotkeys** | — | Array of hotkey objects — bind multiple keys to trigger dictation |
 | **modifiers** | `[]` | `"cmd"`, `"ctrl"`, `"shift"`, `"opt"` — combine for chords |
 | **modelSize** | `"base.en"` | See model table below |
 | **language** | `"en"` | `"auto"` for auto-detect, or any [ISO 639-1 code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) — e.g. `it`, `fr`, `de`, `es` |

--- a/Sources/OpenWispr/AppBundleLaunch.swift
+++ b/Sources/OpenWispr/AppBundleLaunch.swift
@@ -1,0 +1,63 @@
+import AppKit
+import Foundation
+
+enum AppBundleLaunch {
+    private static let bundleMarker = ".app/Contents/MacOS/"
+
+    static func isExecutableInsideAppBundle(_ path: String) -> Bool {
+        path.contains(bundleMarker)
+    }
+
+    static func findOpenWisprAppBundle() -> URL? {
+        if let env = ProcessInfo.processInfo.environment["OPEN_WISPR_APP"]?.trimmingCharacters(in: .whitespacesAndNewlines), !env.isEmpty {
+            let path = (env as NSString).expandingTildeInPath
+            if FileManager.default.fileExists(atPath: path) {
+                return URL(fileURLWithPath: path, isDirectory: true)
+            }
+        }
+
+        let exec = URL(fileURLWithPath: ProcessInfo.processInfo.arguments[0]).resolvingSymlinksInPath()
+        var dir = exec.deletingLastPathComponent()
+        for _ in 0..<10 {
+            let candidate = dir.appendingPathComponent("OpenWispr.app", isDirectory: true)
+            if FileManager.default.fileExists(atPath: candidate.path) {
+                return candidate
+            }
+            let parent = dir.deletingLastPathComponent()
+            if parent.path == dir.path { break }
+            dir = parent
+        }
+
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        let homeApps = home.appendingPathComponent("Applications/OpenWispr.app", isDirectory: true)
+        if FileManager.default.fileExists(atPath: homeApps.path) { return homeApps }
+        let system = URL(fileURLWithPath: "/Applications/OpenWispr.app", isDirectory: true)
+        if FileManager.default.fileExists(atPath: system.path) { return system }
+        return nil
+    }
+
+    @discardableResult
+    static func relaunchThroughAppBundleIfNeeded() -> Bool {
+        let exec = ProcessInfo.processInfo.arguments[0]
+        if isExecutableInsideAppBundle(exec) { return false }
+        guard let appURL = findOpenWisprAppBundle() else { return false }
+
+        fputs("Relaunching via \(appURL.path) so Microphone/Accessibility apply to OpenWispr, not Terminal.\n", stdout)
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+        process.arguments = ["-a", appURL.path, "--args", "start"]
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            fputs("Error: could not start OpenWispr.app: \(error.localizedDescription)\n", stderr)
+            return false
+        }
+        if process.terminationStatus != 0 {
+            fputs("Error: 'open' exited with status \(process.terminationStatus)\n", stderr)
+            return false
+        }
+        return true
+    }
+}

--- a/Sources/OpenWispr/main.swift
+++ b/Sources/OpenWispr/main.swift
@@ -113,7 +113,7 @@ func cmdSetLanguage(_ lang: String) {
 
 func cmdGetHotkey() {
     let config = Config.load()
-    let desc = KeyCodes.describe(keyCode: config.hotkey.keyCode, modifiers: config.hotkey.modifiers)
+    let desc = config.hotkeySummary()
     print("Current hotkey: \(desc)")
 }
 
@@ -128,7 +128,7 @@ func cmdDownloadModel(_ size: String) {
 
 func cmdStatus() {
     let config = Config.load()
-    let hotkeyDesc = KeyCodes.describe(keyCode: config.hotkey.keyCode, modifiers: config.hotkey.modifiers)
+    let hotkeyDesc = config.hotkeySummary()
 
     print("open-wispr v\(version)")
     print("Config:      \(Config.configFile.path)")
@@ -143,10 +143,17 @@ func cmdStatus() {
 }
 
 let args = CommandLine.arguments
-let command = args.count > 1 ? args[1] : nil
+let rawCommand = args.count > 1 ? args[1] : nil
+let command: String? = {
+    if let r = rawCommand, r.hasPrefix("-psn_") { return "start" }
+    return rawCommand
+}()
 
 switch command {
 case "start":
+    if AppBundleLaunch.relaunchThroughAppBundleIfNeeded() {
+        exit(0)
+    }
     cmdStart()
 case "set-hotkey":
     guard args.count > 2 else {

--- a/Sources/OpenWisprLib/AppDelegate.swift
+++ b/Sources/OpenWisprLib/AppDelegate.swift
@@ -2,7 +2,7 @@ import AppKit
 
 public class AppDelegate: NSObject, NSApplicationDelegate {
     var statusBar: StatusBarController!
-    var hotkeyManager: HotkeyManager?
+    var hotkeyManagers: [HotkeyManager] = []
     var recorder: AudioRecorder!
     var transcriber: Transcriber!
     var inserter: TextInserter!
@@ -70,6 +70,7 @@ public class AppDelegate: NSObject, NSApplicationDelegate {
 
         if !AXIsProcessTrusted() {
             print("Accessibility: not granted")
+            Permissions.promptAccessibility()
             Permissions.openAccessibilitySettings()
             print("Waiting for Accessibility permission...")
             while !AXIsProcessTrusted() {
@@ -116,25 +117,29 @@ public class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func startListening() {
-        hotkeyManager = HotkeyManager(
-            keyCode: config.hotkey.keyCode,
-            modifiers: config.hotkey.modifierFlags
-        )
-
-        hotkeyManager?.start(
-            onKeyDown: { [weak self] in
-                self?.handleKeyDown()
-            },
-            onKeyUp: { [weak self] in
-                self?.handleKeyUp()
-            }
-        )
+        for m in hotkeyManagers { m.stop() }
+        hotkeyManagers = []
+        for hk in config.hotkeys {
+            let manager = HotkeyManager(
+                keyCode: hk.keyCode,
+                modifiers: hk.modifierFlags
+            )
+            manager.start(
+                onKeyDown: { [weak self] in
+                    self?.handleKeyDown()
+                },
+                onKeyUp: { [weak self] in
+                    self?.handleKeyUp()
+                }
+            )
+            hotkeyManagers.append(manager)
+        }
 
         isReady = true
         statusBar.state = .idle
         statusBar.buildMenu()
 
-        let hotkeyDesc = KeyCodes.describe(keyCode: config.hotkey.keyCode, modifiers: config.hotkey.modifiers)
+        let hotkeyDesc = config.hotkeySummary()
         print("open-wispr v\(OpenWispr.version)")
         print("Hotkey: \(hotkeyDesc)")
         print("Model: \(config.modelSize)")
@@ -156,15 +161,19 @@ public class AppDelegate: NSObject, NSApplicationDelegate {
         transcriber.spokenPunctuation = config.spokenPunctuation?.value ?? false
         inserter = TextInserter()
 
-        hotkeyManager?.stop()
-        hotkeyManager = HotkeyManager(
-            keyCode: config.hotkey.keyCode,
-            modifiers: config.hotkey.modifierFlags
-        )
-        hotkeyManager?.start(
-            onKeyDown: { [weak self] in self?.handleKeyDown() },
-            onKeyUp: { [weak self] in self?.handleKeyUp() }
-        )
+        for m in hotkeyManagers { m.stop() }
+        hotkeyManagers = []
+        for hk in config.hotkeys {
+            let manager = HotkeyManager(
+                keyCode: hk.keyCode,
+                modifiers: hk.modifierFlags
+            )
+            manager.start(
+                onKeyDown: { [weak self] in self?.handleKeyDown() },
+                onKeyUp: { [weak self] in self?.handleKeyUp() }
+            )
+            hotkeyManagers.append(manager)
+        }
 
         if !wasDownloading && !Transcriber.modelExists(modelSize: config.modelSize) {
             statusBar.state = .downloading
@@ -193,7 +202,7 @@ public class AppDelegate: NSObject, NSApplicationDelegate {
 
         statusBar.buildMenu()
 
-        let hotkeyDesc = KeyCodes.describe(keyCode: config.hotkey.keyCode, modifiers: config.hotkey.modifiers)
+        let hotkeyDesc = config.hotkeySummary()
         print("Config updated: lang=\(config.language) model=\(config.modelSize) hotkey=\(hotkeyDesc)")
     }
 

--- a/Sources/OpenWisprLib/Config.swift
+++ b/Sources/OpenWisprLib/Config.swift
@@ -6,7 +6,7 @@ public struct LanguageOption: Equatable, Sendable {
 }
 
 public struct Config: Codable {
-    public var hotkey: HotkeyConfig
+    public var hotkeys: [HotkeyConfig]
     public var modelPath: String?
     public var modelSize: String
     public var language: String
@@ -14,6 +14,92 @@ public struct Config: Codable {
     public var maxRecordings: Int?
     public var toggleMode: FlexBool?
     public var audioInputDeviceID: UInt32?
+
+    public var hotkey: HotkeyConfig {
+        get { hotkeys[0] }
+        set { hotkeys = Config.deduplicateHotkeys([newValue]) }
+    }
+
+    public func hotkeySummary() -> String {
+        hotkeys
+            .map { KeyCodes.describe(keyCode: $0.keyCode, modifiers: $0.modifiers) }
+            .joined(separator: " · ")
+    }
+
+    private static func deduplicateHotkeys(_ list: [HotkeyConfig]) -> [HotkeyConfig] {
+        var out: [HotkeyConfig] = []
+        for h in list where !out.contains(h) {
+            out.append(h)
+        }
+        return out
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case hotkey
+        case hotkeys
+        case modelPath
+        case modelSize
+        case language
+        case spokenPunctuation
+        case maxRecordings
+        case toggleMode
+        case audioInputDeviceID
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let hotkeysList = try c.decodeIfPresent([HotkeyConfig].self, forKey: .hotkeys)
+        let legacyHotkey = try c.decodeIfPresent(HotkeyConfig.self, forKey: .hotkey)
+        if let list = hotkeysList, !list.isEmpty {
+            self.hotkeys = Config.deduplicateHotkeys(list)
+        } else if let legacy = legacyHotkey {
+            self.hotkeys = [legacy]
+        } else {
+            self.hotkeys = [HotkeyConfig(keyCode: 63, modifiers: [])]
+        }
+        self.modelPath = try c.decodeIfPresent(String.self, forKey: .modelPath)
+        self.modelSize = try c.decode(String.self, forKey: .modelSize)
+        self.language = try c.decode(String.self, forKey: .language)
+        self.spokenPunctuation = try c.decodeIfPresent(FlexBool.self, forKey: .spokenPunctuation)
+        self.maxRecordings = try c.decodeIfPresent(Int.self, forKey: .maxRecordings)
+        self.toggleMode = try c.decodeIfPresent(FlexBool.self, forKey: .toggleMode)
+        self.audioInputDeviceID = try c.decodeIfPresent(UInt32.self, forKey: .audioInputDeviceID)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(hotkeys, forKey: .hotkeys)
+        try c.encode(hotkeys[0], forKey: .hotkey)
+        try c.encodeIfPresent(modelPath, forKey: .modelPath)
+        try c.encode(modelSize, forKey: .modelSize)
+        try c.encode(language, forKey: .language)
+        try c.encodeIfPresent(spokenPunctuation, forKey: .spokenPunctuation)
+        try c.encodeIfPresent(maxRecordings, forKey: .maxRecordings)
+        try c.encodeIfPresent(toggleMode, forKey: .toggleMode)
+        try c.encodeIfPresent(audioInputDeviceID, forKey: .audioInputDeviceID)
+    }
+
+    public init(
+        hotkeys: [HotkeyConfig],
+        modelPath: String?,
+        modelSize: String,
+        language: String,
+        spokenPunctuation: FlexBool?,
+        maxRecordings: Int?,
+        toggleMode: FlexBool?,
+        audioInputDeviceID: UInt32? = nil
+    ) {
+        self.hotkeys = hotkeys.isEmpty
+            ? [HotkeyConfig(keyCode: 63, modifiers: [])]
+            : Config.deduplicateHotkeys(hotkeys)
+        self.modelPath = modelPath
+        self.modelSize = modelSize
+        self.language = language
+        self.spokenPunctuation = spokenPunctuation
+        self.maxRecordings = maxRecordings
+        self.toggleMode = toggleMode
+        self.audioInputDeviceID = audioInputDeviceID
+    }
 
     public static let supportedLanguages: [LanguageOption] = [
         LanguageOption(code: "auto", name: "Auto-Detect"),
@@ -152,7 +238,7 @@ public struct Config: Codable {
     }
 
     public static let defaultConfig = Config(
-        hotkey: HotkeyConfig(keyCode: 63, modifiers: []),
+        hotkeys: [HotkeyConfig(keyCode: 63, modifiers: [])],
         modelPath: nil,
         modelSize: "base.en",
         language: "en",
@@ -230,7 +316,7 @@ public struct FlexBool: Codable {
     }
 }
 
-public struct HotkeyConfig: Codable {
+public struct HotkeyConfig: Codable, Equatable {
     public var keyCode: UInt16
     public var modifiers: [String]
 

--- a/Sources/OpenWisprLib/Permissions.swift
+++ b/Sources/OpenWisprLib/Permissions.swift
@@ -39,14 +39,19 @@ struct Permissions {
             .appendingPathComponent(".config/open-wispr")
         let versionFile = configDir.appendingPathComponent(".last-version")
         let current = OpenWispr.version
-        let previous = try? String(contentsOf: versionFile, encoding: .utf8)
-            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let raw = (try? String(contentsOf: versionFile, encoding: .utf8))?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let previous = raw.isEmpty ? nil : raw
 
+        try? FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+
+        if previous == nil {
+            try? current.write(to: versionFile, atomically: true, encoding: .utf8)
+            return false
+        }
         if previous == current {
             return false
         }
-
-        try? FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
         try? current.write(to: versionFile, atomically: true, encoding: .utf8)
         return true
     }

--- a/Sources/OpenWisprLib/StatusBarController.swift
+++ b/Sources/OpenWisprLib/StatusBarController.swift
@@ -68,7 +68,7 @@ class StatusBarController: NSObject {
         }
         if let text = text, let item = stateMenuItem {
             let config = Config.load()
-            let hotkeyDesc = KeyCodes.describe(keyCode: config.hotkey.keyCode, modifiers: config.hotkey.modifiers)
+            let hotkeyDesc = config.hotkeySummary()
             item.title = "\(text) (hotkey: \(hotkeyDesc))"
         } else {
             buildMenu()
@@ -86,7 +86,7 @@ class StatusBarController: NSObject {
         menuItemTargets = []
 
         let config = Config.load()
-        let hotkeyDesc = KeyCodes.describe(keyCode: config.hotkey.keyCode, modifiers: config.hotkey.modifiers)
+        let hotkeyDesc = config.hotkeySummary()
 
         let menu = NSMenu()
 

--- a/Sources/OpenWisprLib/Version.swift
+++ b/Sources/OpenWisprLib/Version.swift
@@ -1,3 +1,3 @@
 public enum OpenWispr {
-    public static let version = "0.36.0"
+    public static let version = "0.37.0"
 }

--- a/Tests/OpenWisprTests/ConfigTests.swift
+++ b/Tests/OpenWisprTests/ConfigTests.swift
@@ -241,6 +241,60 @@ final class ConfigTests: XCTestCase {
         let config = HotkeyConfig(keyCode: 49, modifiers: ["cmd", "bogus"])
         XCTAssertEqual(config.modifierFlags, UInt64(1 << 20))
     }
+
+    // MARK: - Multiple hotkeys
+
+    func testConfigDecodesHotkeysArray() throws {
+        let json = """
+        {
+            "hotkeys": [
+                {"keyCode": 63, "modifiers": []},
+                {"keyCode": 96, "modifiers": []}
+            ],
+            "modelSize": "base.en",
+            "language": "en"
+        }
+        """.data(using: .utf8)!
+        let config = try Config.decode(from: json)
+        XCTAssertEqual(config.hotkeys.count, 2)
+        XCTAssertEqual(config.hotkey.keyCode, 63)
+        XCTAssertTrue(config.hotkeySummary().contains("·"))
+    }
+
+    func testConfigDeduplicatesIdenticalHotkeys() throws {
+        let json = """
+        {
+            "hotkeys": [
+                {"keyCode": 63, "modifiers": []},
+                {"keyCode": 63, "modifiers": []}
+            ],
+            "modelSize": "base.en",
+            "language": "en"
+        }
+        """.data(using: .utf8)!
+        let config = try Config.decode(from: json)
+        XCTAssertEqual(config.hotkeys.count, 1)
+    }
+
+    func testConfigEncodeRoundtripPreservesHotkeys() throws {
+        let json = """
+        {
+            "hotkeys": [
+                {"keyCode": 63, "modifiers": []},
+                {"keyCode": 96, "modifiers": []}
+            ],
+            "modelSize": "base.en",
+            "language": "en"
+        }
+        """.data(using: .utf8)!
+        let config = try Config.decode(from: json)
+        let data = try JSONEncoder().encode(config)
+        let again = try Config.decode(from: data)
+        XCTAssertEqual(again.hotkeys.count, 2)
+        let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        XCTAssertNotNil(obj?["hotkey"])
+        XCTAssertNotNil(obj?["hotkeys"])
+    }
 }
 
 private struct FlexBoolWrapper: Codable {


### PR DESCRIPTION
## Summary
- **Config:** Support a `hotkeys` array (with backward-compatible single `hotkey`); dedupe; `hotkeySummary()` for status/menu.
- **App:** Register one `HotkeyManager` per configured hotkey.
- **CLI:** Treat Finder `-psn_*` argv as `start`; when not running inside `.app`, relaunch via `OpenWispr.app` so TCC (mic/accessibility) applies to the app, not Terminal.
- **Permissions:** Prompt accessibility before opening Settings; fix first-run `.last-version` behavior.
- **Tests:** Decode/encode and dedupe coverage for multiple hotkeys.

## Test plan
- `swift test` (passed locally)

cc @human37 — happy to adjust scope or docs if you want hotkeys documented in README separately.

Made with [Cursor](https://cursor.com)