### PR TITLE
Fix mic indicator always on

### DIFF
--- a/Sources/OpenWisprLib/AudioRecorder.swift
+++ b/Sources/OpenWisprLib/AudioRecorder.swift
@@ -4,14 +4,10 @@ import Foundation
 
 class AudioRecorder {
     private var audioEngine: AVAudioEngine?
-    private var inputFormat: AVAudioFormat?
     private var isRecording = false
     private var currentOutputURL: URL?
     var preferredDeviceID: AudioDeviceID?
 
-    /// Bring the audio engine online and keep it running. Subsequent
-    /// startRecording calls only need to install a tap, which is cheap;
-    /// the ~600ms cost of engine.start() is paid once at app launch.
     func prewarm() {
         guard audioEngine == nil else { return }
 
@@ -22,18 +18,8 @@ class AudioRecorder {
             setInputDevice(deviceID, on: engine)
         }
 
-        let format = engine.inputNode.outputFormat(forBus: 0)
-
-        do {
-            engine.prepare()
-            try engine.start()
-        } catch {
-            print("Audio engine prewarm error: \(error.localizedDescription)")
-            return
-        }
-
+        engine.prepare()
         audioEngine = engine
-        inputFormat = format
     }
 
     /// Stop and release the engine. Call before changing input device or on shutdown.
@@ -45,7 +31,6 @@ class AudioRecorder {
         }
         audioEngine?.stop()
         audioEngine = nil
-        inputFormat = nil
     }
 
     /// Re-prewarm with the current preferredDeviceID. Use after a config change.
@@ -61,13 +46,17 @@ class AudioRecorder {
             prewarm()
         }
 
-        guard let engine = audioEngine, let inputFmt = inputFormat else {
+        guard let engine = audioEngine else {
             throw NSError(
                 domain: "OpenWispr.AudioRecorder",
                 code: 1,
                 userInfo: [NSLocalizedDescriptionKey: "Audio engine is not available"]
             )
         }
+
+        try engine.start()
+
+        let inputFmt = engine.inputNode.outputFormat(forBus: 0)
 
         let recordingFormat = AVAudioFormat(
             commonFormat: .pcmFormatFloat32,
@@ -121,6 +110,7 @@ class AudioRecorder {
         currentOutputURL = nil
 
         audioEngine?.inputNode.removeTap(onBus: 0)
+        audioEngine?.stop()
 
         return url
     }

--- a/Sources/OpenWisprLib/AudioRecorder.swift
+++ b/Sources/OpenWisprLib/AudioRecorder.swift
@@ -18,6 +18,7 @@ class AudioRecorder {
             setInputDevice(deviceID, on: engine)
         }
 
+        _ = engine.inputNode
         engine.prepare()
         audioEngine = engine
     }

--- a/Sources/OpenWisprLib/Version.swift
+++ b/Sources/OpenWisprLib/Version.swift
@@ -1,3 +1,3 @@
 public enum OpenWispr {
-    public static let version = "0.38.0"
+    public static let version = "0.39.0"
 }


### PR DESCRIPTION
Fixes #61.

`prewarm()` was calling `engine.start()` at launch, which claims the microphone indefinitely and causes macOS to show the orange mic indicator at all times.

**What changed:**
- `prewarm()` now only calls `engine.prepare()`, which warms up the audio unit loading without starting the engine or claiming the mic
- `startRecording()` calls `engine.start()` just before installing the tap, so the mic indicator appears only during active dictation
- `stopRecording()` calls `engine.stop()` after removing the tap, so the mic indicator disappears as soon as recording ends

The audio unit preparation work (the expensive part of the original ~600ms startup cost) is still done at launch via `prepare()`, so startup latency on first keypress should be minimal compared to a fully cold start.