### PR TITLE
fix: handle Homebrew trust install failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ curl -fsSL https://raw.githubusercontent.com/human37/open-wispr/main/scripts/ins
 
 The script handles everything: installs via Homebrew, walks you through granting permissions, downloads the Whisper model, and starts the service. You'll see live feedback as each step completes.
 
+> **Note:** Recent versions of Homebrew (6.0+) have tightened security around third-party taps, so you may be asked to trust this package before it installs. If that happens, the installer prints the exact `brew trust` command to run.
+
 A waveform icon appears in your menu bar when it's running.
 
 The default hotkey is the **Globe key** (🌐, bottom-left). Hold it, speak, release.

--- a/Sources/OpenWisprLib/Version.swift
+++ b/Sources/OpenWisprLib/Version.swift
@@ -1,3 +1,3 @@
 public enum OpenWispr {
-    public static let version = "0.41.0"
+    public static let version = "0.42.0"
 }

--- a/docs/install-guide.md
+++ b/docs/install-guide.md
@@ -10,7 +10,7 @@ The installer handles everything automatically — Homebrew tap, formula install
 
 ## What the installer does
 
-1. **Installs via Homebrew** — taps `human37/open-wispr` and installs the formula
+1. **Installs via Homebrew** — taps `human37/open-wispr` and installs the formula. Recent versions of Homebrew (6.0+) have tightened security around third-party taps, so you may be asked to trust the package first — the installer prints the exact `brew trust` command to run if so.
 2. **Copies the app bundle** to `~/Applications/OpenWispr.app`
 3. **Requests permissions** — Microphone and Accessibility
 4. **Downloads the Whisper model** (~142 MB, one-time)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -83,6 +83,74 @@ die() {
     exit 1
 }
 
+restore_formula() {
+    if [ -n "$VERSION" ] && [ -n "$TAP_DIR" ]; then
+        git -C "$TAP_DIR" checkout main -- open-wispr.rb 2>/dev/null || true
+    fi
+}
+
+is_homebrew_trust_error() {
+    local output="$1"
+    printf "%s\n" "$output" | grep -Eiq "(tap.*not trusted|formula.*not trusted|not trusted.*(tap|formula)|untrusted (tap|formula)|brew trust --(formula|tap))"
+}
+
+homebrew_trust_command() {
+    local output="$1"
+    local trust_command
+
+    trust_command=$(
+        printf "%s\n" "$output" |
+            grep -Eo "brew trust --(formula|tap)[[:space:]]+[^[:space:]]+" |
+            head -n 1 |
+            tr -d '`'
+    )
+    trust_command="${trust_command%.}"
+    trust_command="${trust_command%,}"
+
+    if [ -n "$trust_command" ]; then
+        printf "%s\n" "$trust_command"
+    else
+        printf "brew trust --formula human37/open-wispr/open-wispr\n"
+    fi
+}
+
+die_homebrew_trust_error() {
+    local output="$1"
+    local trust_command
+
+    stop_spin
+    restore_formula
+
+    fail "Homebrew requires trust before installing open-wispr."
+    printf "\n"
+    info "Homebrew reported:"
+    while IFS= read -r line; do
+        [ -n "$line" ] && info "$line"
+    done <<< "$output"
+
+    trust_command="$(homebrew_trust_command "$output")"
+
+    printf "\n"
+    info "If you trust human37/open-wispr, run:"
+    printf "\n"
+    printf "  ${BOLD}%s${NC}\n" "$trust_command"
+    printf "\n"
+    info "Then re-run this installer."
+    exit 1
+}
+
+run_brew_install_step() {
+    local action="$1"
+    local output
+    local status
+
+    output=$(brew "$action" open-wispr </dev/null 2>&1)
+    status=$?
+    if [ "$status" -ne 0 ] && is_homebrew_trust_error "$output"; then
+        die_homebrew_trust_error "$output"
+    fi
+}
+
 # ── Parse arguments ──────────────────────────────────────────────────
 VERSION=""
 while [[ $# -gt 0 ]]; do
@@ -162,11 +230,10 @@ if [ -n "$VERSION" ]; then
 fi
 
 start_spin "Installing open-wispr${VERSION:+ v$VERSION}..."
-brew install open-wispr </dev/null >/dev/null 2>&1 || true
-brew reinstall open-wispr </dev/null >/dev/null 2>&1 || true
-if [ -n "$VERSION" ]; then
-    git -C "$TAP_DIR" checkout main -- open-wispr.rb 2>/dev/null || true
-fi
+run_brew_install_step install
+run_brew_install_step reinstall
+
+restore_formula
 stop_spin
 
 BREW_PREFIX="$(brew --prefix open-wispr 2>/dev/null)"

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -7,6 +7,14 @@ FAIL=0
 pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
 fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
 
+INSTALLER_TRUST_TMPDIR=""
+
+cleanup_installer_trust() {
+    if [ -n "$INSTALLER_TRUST_TMPDIR" ]; then
+        rm -rf "$INSTALLER_TRUST_TMPDIR"
+    fi
+}
+
 check_output() {
     local description="$1"
     local pattern="$2"
@@ -19,6 +27,158 @@ check_output() {
         fail "$description"
     fi
 }
+
+run_stubbed_installer() {
+    local failure_mode="$1"
+
+    PATH="$INSTALLER_TRUST_TMPDIR/bin:$PATH" \
+    HOME="$INSTALLER_TRUST_TMPDIR/home" \
+    OPEN_WISPR_TEST_TAP_DIR="$INSTALLER_TRUST_TMPDIR/tap" \
+    OPEN_WISPR_TEST_PREFIX_DIR="$INSTALLER_TRUST_TMPDIR/prefix" \
+    OPEN_WISPR_TEST_BREW_FAILURE="$failure_mode" \
+    bash scripts/install.sh 2>&1
+}
+
+check_trust_failure_output() {
+    local description="$1"
+    local output="$2"
+    local status="$3"
+
+    if [ "$status" -eq 0 ]; then
+        fail "$description exits non-zero"
+    elif echo "$output" | grep -q "binary not found"; then
+        fail "$description does not fall through to binary-not-found"
+    elif ! echo "$output" | grep -q "tap is not trusted"; then
+        fail "$description explains Homebrew trust"
+    elif ! echo "$output" | grep -q -- "brew trust --formula human37/open-wispr/open-wispr"; then
+        fail "$description prints remediation command"
+    else
+        pass "$description prints remediation without binary fallback"
+    fi
+}
+
+run_installer_trust_test() {
+    local output
+    local status
+
+    INSTALLER_TRUST_TMPDIR=$(mktemp -d /tmp/open-wispr-installer-trust.XXXXXX)
+
+    mkdir -p "$INSTALLER_TRUST_TMPDIR/bin" "$INSTALLER_TRUST_TMPDIR/home" "$INSTALLER_TRUST_TMPDIR/tap"
+
+    cat > "$INSTALLER_TRUST_TMPDIR/bin/uname" <<'STUB'
+#!/bin/bash
+if [ "${1:-}" = "-m" ]; then
+    echo "arm64"
+    exit 0
+fi
+exec /usr/bin/uname "$@"
+STUB
+
+    cat > "$INSTALLER_TRUST_TMPDIR/bin/brew" <<'STUB'
+#!/bin/bash
+set -u
+
+print_trust_error() {
+    echo "Error: Cannot install human37/open-wispr/open-wispr because its tap is not trusted" >&2
+    echo "To trust this formula, run:" >&2
+    echo "  brew trust --formula human37/open-wispr/open-wispr" >&2
+}
+
+case "${1:-}" in
+    list)
+        exit 1
+        ;;
+    tap)
+        exit 0
+        ;;
+    --repository)
+        if [ "${2:-}" = "human37/open-wispr" ]; then
+            echo "${OPEN_WISPR_TEST_TAP_DIR:?}"
+            exit 0
+        fi
+        ;;
+    install)
+        if [ "${2:-}" = "open-wispr" ]; then
+            case "${OPEN_WISPR_TEST_BREW_FAILURE:-install-trust}" in
+                install-trust)
+                    print_trust_error
+                    exit 1
+                    ;;
+                reinstall-trust)
+                    exit 0
+                    ;;
+                generic)
+                    echo "Error: failed to download bottle" >&2
+                    exit 1
+                    ;;
+            esac
+        fi
+        ;;
+    reinstall)
+        if [ "${2:-}" = "open-wispr" ]; then
+            case "${OPEN_WISPR_TEST_BREW_FAILURE:-install-trust}" in
+                reinstall-trust)
+                    print_trust_error
+                    exit 1
+                    ;;
+                generic)
+                    echo "Error: failed to download bottle" >&2
+                    exit 1
+                    ;;
+                *)
+                    exit 0
+                    ;;
+            esac
+        fi
+        ;;
+    --prefix)
+        if [ "${2:-}" = "open-wispr" ]; then
+            echo "${OPEN_WISPR_TEST_PREFIX_DIR:?}"
+            exit 0
+        fi
+        ;;
+esac
+
+echo "unexpected brew invocation: $*" >&2
+exit 1
+STUB
+
+    chmod +x "$INSTALLER_TRUST_TMPDIR/bin/uname" "$INSTALLER_TRUST_TMPDIR/bin/brew"
+
+    output=$(run_stubbed_installer install-trust)
+    status=$?
+    check_trust_failure_output "installer trust error from brew install" "$output" "$status"
+
+    output=$(run_stubbed_installer reinstall-trust)
+    status=$?
+    check_trust_failure_output "installer trust error from brew reinstall" "$output" "$status"
+
+    output=$(run_stubbed_installer generic)
+    status=$?
+
+    if [ "$status" -eq 0 ]; then
+        fail "generic installer failure exits non-zero"
+    elif ! echo "$output" | grep -q "binary not found"; then
+        fail "generic installer failure keeps binary-not-found fallback"
+    elif echo "$output" | grep -q "brew trust"; then
+        fail "generic installer failure does not print trust remediation"
+    else
+        pass "generic installer failure keeps binary fallback"
+    fi
+
+    cleanup_installer_trust
+}
+
+if [ "${1:-}" = "--installer-trust" ]; then
+    echo "open-wispr installer trust test"
+    echo "-------------------------------"
+    run_installer_trust_test
+    echo ""
+    echo "-------------------------------"
+    echo "Results: $PASS passed, $FAIL failed"
+    [ "$FAIL" -eq 0 ] || exit 1
+    exit 0
+fi
 
 CONFIG_FILE="$HOME/.config/open-wispr/config.json"
 CONFIG_BACKUP=""
@@ -39,6 +199,10 @@ restore_config() {
 
 echo "open-wispr install smoke tests"
 echo "-------------------------------"
+
+echo ""
+echo "Testing installer trust handling..."
+run_installer_trust_test
 
 echo ""
 echo "Building..."


### PR DESCRIPTION
## Summary
- Detect Homebrew tap/formula trust failures during the guided installer
- Show the Homebrew trust remediation command instead of falling through to the misleading binary-not-found error
- Add stubbed installer coverage for trust failures from both `brew install` and `brew reinstall`

Fixes #72

## Verification
- `bash -n scripts/install.sh scripts/test-install.sh` -> passed
- `git diff --check upstream/main...HEAD` -> passed
- `bash scripts/test-install.sh --installer-trust` -> 3 passed, 0 failed
- `bash scripts/test-install.sh` -> 17 passed, 0 failed

## Caveats
- `shellcheck` was not installed locally, so the local install smoke test skipped shellcheck. CI installs shellcheck before running `bash scripts/test-install.sh`.
- No Swift files changed, so `swift test` was not run locally.
