### PR TITLE
Add configurable Whisper prompt support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Edit `~/.config/open-wispr/config.json`:
   "modelSize": "base.en",
   "language": "en",
   "spokenPunctuation": false,
+  "whisperPrompt": "Use punctuation and capitalization.",
   "maxRecordings": 0,
   "toggleMode": false
 }
@@ -74,6 +75,7 @@ Both `hotkey` (single) and `hotkeys` (array) are supported. If both are present,
 | **modelSize** | `"base.en"` | See model table below |
 | **language** | `"en"` | `"auto"` for auto-detect, or any [ISO 639-1 code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) — e.g. `it`, `fr`, `de`, `es` |
 | **spokenPunctuation** | `false` | Say "comma", "period", etc. to insert punctuation instead of auto-punctuation |
+| **whisperPrompt** | — | Optional prompt text passed to Whisper to guide style, vocabulary, or punctuation. Omit it or leave it blank to use Whisper's default behavior. |
 | **maxRecordings** | `0` | Optionally store past recordings locally as `.wav` files for re-transcribing from the tray menu. `0` = nothing stored (default). Set 1-100 to keep that many recent recordings. |
 | **toggleMode** | `false` | Press hotkey once to start recording, press again to stop. Default is hold-to-talk. |
 

--- a/Sources/OpenWisprLib/AppDelegate.swift
+++ b/Sources/OpenWisprLib/AppDelegate.swift
@@ -39,8 +39,7 @@ public class AppDelegate: NSObject, NSApplicationDelegate {
         if Config.effectiveMaxRecordings(config.maxRecordings) == 0 {
             RecordingStore.deleteAllRecordings()
         }
-        transcriber = Transcriber(modelSize: config.modelSize, language: config.language)
-        transcriber.spokenPunctuation = config.spokenPunctuation?.value ?? false
+        transcriber = makeTranscriber(for: config)
 
         DispatchQueue.main.async {
             self.statusBar.reprocessHandler = { [weak self] url in
@@ -182,8 +181,7 @@ public class AppDelegate: NSObject, NSApplicationDelegate {
         if deviceChanged {
             recorder.reload()
         }
-        transcriber = Transcriber(modelSize: config.modelSize, language: config.language)
-        transcriber.spokenPunctuation = config.spokenPunctuation?.value ?? false
+        transcriber = makeTranscriber(for: config)
         inserter = TextInserter()
 
         for m in hotkeyManagers { m.stop() }
@@ -229,6 +227,16 @@ public class AppDelegate: NSObject, NSApplicationDelegate {
 
         let hotkeyDesc = config.hotkeySummary()
         print("Config updated: lang=\(config.language) model=\(config.modelSize) hotkey=\(hotkeyDesc)")
+    }
+
+    private func makeTranscriber(for config: Config) -> Transcriber {
+        let transcriber = Transcriber(
+            modelSize: config.modelSize,
+            language: config.language,
+            whisperPrompt: config.whisperPrompt
+        )
+        transcriber.spokenPunctuation = config.spokenPunctuation?.value ?? false
+        return transcriber
     }
 
     private func handleKeyDown() {

--- a/Sources/OpenWisprLib/Config.swift
+++ b/Sources/OpenWisprLib/Config.swift
@@ -10,6 +10,7 @@ public struct Config: Codable {
     public var modelPath: String?
     public var modelSize: String
     public var language: String
+    public var whisperPrompt: String?
     public var spokenPunctuation: FlexBool?
     public var maxRecordings: Int?
     public var toggleMode: FlexBool?
@@ -41,6 +42,7 @@ public struct Config: Codable {
         case modelPath
         case modelSize
         case language
+        case whisperPrompt
         case spokenPunctuation
         case maxRecordings
         case toggleMode
@@ -62,6 +64,7 @@ public struct Config: Codable {
         self.modelPath = try c.decodeIfPresent(String.self, forKey: .modelPath)
         self.modelSize = try c.decode(String.self, forKey: .modelSize)
         self.language = try c.decode(String.self, forKey: .language)
+        self.whisperPrompt = try c.decodeIfPresent(String.self, forKey: .whisperPrompt)
         self.spokenPunctuation = try c.decodeIfPresent(FlexBool.self, forKey: .spokenPunctuation)
         self.maxRecordings = try c.decodeIfPresent(Int.self, forKey: .maxRecordings)
         self.toggleMode = try c.decodeIfPresent(FlexBool.self, forKey: .toggleMode)
@@ -76,6 +79,7 @@ public struct Config: Codable {
         try c.encodeIfPresent(modelPath, forKey: .modelPath)
         try c.encode(modelSize, forKey: .modelSize)
         try c.encode(language, forKey: .language)
+        try c.encodeIfPresent(whisperPrompt, forKey: .whisperPrompt)
         try c.encodeIfPresent(spokenPunctuation, forKey: .spokenPunctuation)
         try c.encodeIfPresent(maxRecordings, forKey: .maxRecordings)
         try c.encodeIfPresent(toggleMode, forKey: .toggleMode)
@@ -88,6 +92,7 @@ public struct Config: Codable {
         modelPath: String?,
         modelSize: String,
         language: String,
+        whisperPrompt: String? = nil,
         spokenPunctuation: FlexBool?,
         maxRecordings: Int?,
         toggleMode: FlexBool?,
@@ -100,6 +105,7 @@ public struct Config: Codable {
         self.modelPath = modelPath
         self.modelSize = modelSize
         self.language = language
+        self.whisperPrompt = whisperPrompt
         self.spokenPunctuation = spokenPunctuation
         self.maxRecordings = maxRecordings
         self.toggleMode = toggleMode
@@ -248,6 +254,7 @@ public struct Config: Codable {
         modelPath: nil,
         modelSize: "base.en",
         language: "en",
+        whisperPrompt: nil,
         spokenPunctuation: FlexBool(false),
         maxRecordings: nil,
         toggleMode: FlexBool(false)

--- a/Sources/OpenWisprLib/Transcriber.swift
+++ b/Sources/OpenWisprLib/Transcriber.swift
@@ -3,11 +3,13 @@ import Foundation
 public class Transcriber {
     private let modelSize: String
     private let language: String
+    private let whisperPrompt: String?
     public var spokenPunctuation: Bool = false
 
-    public init(modelSize: String = "base.en", language: String = "en") {
+    public init(modelSize: String = "base.en", language: String = "en", whisperPrompt: String? = nil) {
         self.modelSize = modelSize
         self.language = language
+        self.whisperPrompt = whisperPrompt
     }
 
     public func transcribe(audioURL: URL) throws -> String {
@@ -21,17 +23,7 @@ public class Transcriber {
 
         let process = Process()
         process.executableURL = URL(fileURLWithPath: whisperPath)
-        var args = [
-            "-m", modelPath,
-            "-f", audioURL.path,
-            "-l", language,
-            "--no-timestamps",
-            "-nt",
-        ]
-        if spokenPunctuation {
-            args += ["--suppress-regex", "[,\\.\\?!;:\\-—]"]
-        }
-        process.arguments = args
+        process.arguments = arguments(modelPath: modelPath, audioURL: audioURL)
 
         let stdoutPipe = Pipe()
         let stderrPipe = Pipe()
@@ -61,6 +53,29 @@ public class Transcriber {
         }
 
         return output
+    }
+
+    func arguments(modelPath: String, audioURL: URL) -> [String] {
+        var args = [
+            "-m", modelPath,
+            "-f", audioURL.path,
+            "-l", language,
+            "--no-timestamps",
+            "-nt",
+        ]
+        if let prompt = effectiveWhisperPrompt {
+            args += ["--prompt", prompt]
+        }
+        if spokenPunctuation {
+            args += ["--suppress-regex", "[,\\.\\?!;:\\-—]"]
+        }
+
+        return args
+    }
+
+    private var effectiveWhisperPrompt: String? {
+        guard let whisperPrompt else { return nil }
+        return whisperPrompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : whisperPrompt
     }
 
     private static let knownMarkers: Set<String> = [

--- a/Tests/OpenWisprTests/ConfigTests.swift
+++ b/Tests/OpenWisprTests/ConfigTests.swift
@@ -88,6 +88,33 @@ final class ConfigTests: XCTestCase {
         XCTAssertEqual(Config.effectiveMaxRecordings(config.maxRecordings), 0)
     }
 
+    func testConfigDecodesWhisperPrompt() throws {
+        let json = """
+        {
+            "hotkey": {"keyCode": 63, "modifiers": []},
+            "modelSize": "base",
+            "language": "auto",
+            "whisperPrompt": "Use punctuation and capitalization."
+        }
+        """.data(using: .utf8)!
+        let config = try Config.decode(from: json)
+        XCTAssertEqual(config.whisperPrompt, "Use punctuation and capitalization.")
+    }
+
+    func testConfigEncodesWhisperPromptRoundTrip() throws {
+        var config = Config.defaultConfig
+        config.whisperPrompt = "Prefer concise sentences."
+        let data = try JSONEncoder().encode(config)
+        let decoded = try Config.decode(from: data)
+        XCTAssertEqual(decoded.whisperPrompt, "Prefer concise sentences.")
+    }
+
+    func testConfigOmitsWhisperPromptWhenNil() throws {
+        let data = try JSONEncoder().encode(Config.defaultConfig)
+        let json = String(data: data, encoding: .utf8)!
+        XCTAssertFalse(json.contains("whisperPrompt"))
+    }
+
     // MARK: - toggleMode decoding
 
     func testConfigDecodesToggleModeTrue() throws {

--- a/Tests/OpenWisprTests/TranscriberTests.swift
+++ b/Tests/OpenWisprTests/TranscriberTests.swift
@@ -3,6 +3,68 @@ import XCTest
 
 final class TranscriberTests: XCTestCase {
 
+    func testArgumentsIncludeWhisperPromptAsSingleFollowingArgument() throws {
+        let prompt = "  Use punctuation, keep product names like OpenWispr.  "
+        let transcriber = Transcriber(
+            modelSize: "base.en",
+            language: "en",
+            whisperPrompt: prompt
+        )
+        let args = transcriber.arguments(
+            modelPath: "/models/ggml-base.en.bin",
+            audioURL: URL(fileURLWithPath: "/tmp/input.wav")
+        )
+
+        let promptFlagIndex = try XCTUnwrap(args.firstIndex(of: "--prompt"))
+        XCTAssertEqual(args[promptFlagIndex + 1], prompt)
+        XCTAssertEqual(args.filter { $0 == prompt }.count, 1)
+    }
+
+    func testArgumentsOmitNilWhisperPrompt() {
+        let transcriber = Transcriber(modelSize: "base.en", language: "en")
+        let args = transcriber.arguments(
+            modelPath: "/models/ggml-base.en.bin",
+            audioURL: URL(fileURLWithPath: "/tmp/input.wav")
+        )
+
+        XCTAssertFalse(args.contains("--prompt"))
+    }
+
+    func testArgumentsOmitWhitespaceOnlyWhisperPrompt() {
+        let transcriber = Transcriber(
+            modelSize: "base.en",
+            language: "en",
+            whisperPrompt: " \n\t "
+        )
+        let args = transcriber.arguments(
+            modelPath: "/models/ggml-base.en.bin",
+            audioURL: URL(fileURLWithPath: "/tmp/input.wav")
+        )
+
+        XCTAssertFalse(args.contains("--prompt"))
+    }
+
+    func testArgumentsKeepSuppressRegexWhenSpokenPunctuationUsesPrompt() throws {
+        let prompt = "Use punctuation and short sentences."
+        let transcriber = Transcriber(
+            modelSize: "base.en",
+            language: "en",
+            whisperPrompt: prompt
+        )
+        transcriber.spokenPunctuation = true
+
+        let args = transcriber.arguments(
+            modelPath: "/models/ggml-base.en.bin",
+            audioURL: URL(fileURLWithPath: "/tmp/input.wav")
+        )
+
+        let promptFlagIndex = try XCTUnwrap(args.firstIndex(of: "--prompt"))
+        XCTAssertEqual(args[promptFlagIndex + 1], prompt)
+
+        let suppressFlagIndex = try XCTUnwrap(args.firstIndex(of: "--suppress-regex"))
+        XCTAssertEqual(args[suppressFlagIndex + 1], "[,\\.\\?!;:\\-—]")
+    }
+
     func testBlankAudioMarker() {
         XCTAssertEqual(Transcriber.stripWhisperMarkers("[BLANK_AUDIO]"), "")
     }


### PR DESCRIPTION
## Summary

- Add optional `whisperPrompt` support to `config.json`.
- Pass a configured non-blank prompt through to `whisper-cli` as `--prompt <value>`.
- Document the option and cover config/argument behavior with unit tests.

## Why

Fixes #70.

This lets users provide their own Whisper prompt for style, vocabulary, or punctuation guidance without hard-coding Chinese-specific behavior or changing the default transcription path.

## Tests

- `git diff --check upstream/main`
- `swift test --filter ConfigTests` - 41 tests, 0 failures
- `swift test --filter TranscriberTests` - 16 tests, 0 failures
- `swift test` - 111 tests, 0 failures
- `swift build -c release`

## Scope / non-goals

- Generic optional config only; no built-in prompt text and no language-specific special case.
- No GUI, CLI setter, custom dictionary behavior, post-processing behavior, or cloud dependency.
- Nil or whitespace-only prompt values omit `--prompt`, preserving default Whisper behavior.

## Caveats

- Live punctuation quality depends on Whisper/model/audio behavior; this PR proves config plumbing and exact CLI argument construction locally.
- Related active work: draft PR #42 also uses `--prompt` for custom dictionary hints, and PR #76 also touches `Transcriber.swift` argument construction. This PR keeps prompt support minimal so future composition remains straightforward.
