### PR TITLE
Recover audio recorder after device changes, plus a manual Restart Audio Engine item

### DIFF
--- a/Sources/OpenWisprLib/AppDelegate.swift
+++ b/Sources/OpenWisprLib/AppDelegate.swift
@@ -438,6 +438,11 @@ public class AppDelegate: NSObject, NSApplicationDelegate {
             legacyID: config.audioInputDeviceID
         )
         recorder.reload()
+        // Rebuild the menu so the "Audio Input:" line reflects reality: when the
+        // pinned device is gone resolveConfiguredDeviceID returns nil, and the menu
+        // must fall back to "System Default" and move the checkmark instead of
+        // naming a mic that's no longer physically connected.
+        statusBar.buildMenu()
     }
 
     private func registerSleepWakeObservers() {

--- a/Sources/OpenWisprLib/AppDelegate.swift
+++ b/Sources/OpenWisprLib/AppDelegate.swift
@@ -59,6 +59,9 @@ public class AppDelegate: NSObject, NSApplicationDelegate {
             self.statusBar.onConfigChange = { [weak self] newConfig in
                 self?.applyConfigChange(newConfig)
             }
+            self.statusBar.restartAudioHandler = { [weak self] in
+                self?.restartAudioEngine()
+            }
             self.statusBar.buildMenu()
         }
 
@@ -169,6 +172,29 @@ public class AppDelegate: NSObject, NSApplicationDelegate {
     public func reloadConfig() {
         let newConfig = Config.load()
         applyConfigChange(newConfig)
+    }
+
+    /// User-invoked from the menu bar: rebuild the audio engine bound to the
+    /// currently configured input device. The auto-recovery observers catch
+    /// most device changes, but this is the manual escape hatch if the engine
+    /// is ever left stranded — the hotkey fires and a WAV is written, but it
+    /// captures no audio — without changing the configured device or restarting
+    /// the app.
+    public func restartAudioEngine() {
+        guard isReady else { return }
+        switch recordingLifecycle.manualEngineRestart(isReady: isReady) {
+        case .cancelRecording:
+            print("Restart audio engine requested mid-recording, cancelling recording")
+            recorder.teardown()
+            RecordingCancellation.discardTrackedPartialRecording(&currentRecordingURL)
+            resetRecordingStatusToIdleIfNeeded()
+            prepareRecorderForCurrentDevices()
+        case .prepareRecorder:
+            print("Manually restarting audio engine")
+            prepareRecorderForCurrentDevices()
+        case .none, .startRecording, .stopRecording:
+            break
+        }
     }
 
     /// Configs written by older versions store only the numeric AudioDeviceID,

--- a/Sources/OpenWisprLib/AppDelegate.swift
+++ b/Sources/OpenWisprLib/AppDelegate.swift
@@ -9,6 +9,7 @@ public class AppDelegate: NSObject, NSApplicationDelegate {
     var config: Config!
     var recordingLifecycle = RecordingLifecycle()
     var currentRecordingURL: URL?
+    private var reloadRecorderAfterRecording = false
     private var sleepWakeObservers: [NSObjectProtocol] = []
     var isReady = false
     public var lastTranscription: String?
@@ -16,6 +17,9 @@ public class AppDelegate: NSObject, NSApplicationDelegate {
     public func applicationDidFinishLaunching(_ notification: Notification) {
         statusBar = StatusBarController()
         recorder = AudioRecorder()
+        recorder.onConfigurationChange = { [weak self] in
+            self?.handleAudioConfigurationChange()
+        }
         registerSleepWakeObservers()
 
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
@@ -150,6 +154,10 @@ public class AppDelegate: NSObject, NSApplicationDelegate {
         isReady = true
         statusBar.state = .idle
         statusBar.buildMenu()
+
+        AudioDeviceManager.startDeviceChangeMonitoring { [weak self] in
+            self?.handleAudioDevicesChanged()
+        }
 
         let hotkeyDesc = config.hotkeySummary()
         print("open-wispr v\(OpenWispr.version)")
@@ -294,11 +302,13 @@ public class AppDelegate: NSObject, NSApplicationDelegate {
         guard let audioURL = recorder.stopRecording() else {
             RecordingCancellation.discardTrackedPartialRecording(&currentRecordingURL)
             statusBar.state = .idle
+            reloadRecorderAfterRecordingIfNeeded()
             return
         }
 
         currentRecordingURL = nil
         statusBar.state = .transcribing
+        reloadRecorderAfterRecordingIfNeeded()
 
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             guard let self = self else { return }
@@ -352,6 +362,51 @@ public class AppDelegate: NSObject, NSApplicationDelegate {
     func handleSystemDidWake() {
         guard recordingLifecycle.systemDidWake(isReady: isReady) == .prepareRecorder else { return }
 
+        prepareRecorderForCurrentDevices()
+    }
+
+    func handleAudioConfigurationChange() {
+        switch recordingLifecycle.audioConfigurationChanged(isReady: isReady) {
+        case .cancelRecording:
+            print("Audio device configuration changed mid-recording, cancelling and reloading recorder")
+            recorder.teardown()
+            RecordingCancellation.discardTrackedPartialRecording(&currentRecordingURL)
+            resetRecordingStatusToIdleIfNeeded()
+            prepareRecorderForCurrentDevices()
+        case .prepareRecorder:
+            print("Audio device configuration changed, reloading recorder")
+            prepareRecorderForCurrentDevices()
+        case .none, .startRecording, .stopRecording:
+            break
+        }
+    }
+
+    /// A device was added or removed, or the default input changed. Don't
+    /// kill an in-flight recording for this — the engine usually survives a
+    /// topology change — but rebuild at the next opportunity so the recorder
+    /// is bound to devices that still exist. If the engine actually died
+    /// mid-recording, the AVAudioEngineConfigurationChange path cancels the
+    /// recording instead.
+    func handleAudioDevicesChanged() {
+        guard isReady else { return }
+        if recordingLifecycle.isRecording {
+            reloadRecorderAfterRecording = true
+            return
+        }
+        print("Audio devices changed, reloading recorder")
+        prepareRecorderForCurrentDevices()
+    }
+
+    private func reloadRecorderAfterRecordingIfNeeded() {
+        guard reloadRecorderAfterRecording else { return }
+        print("Audio devices changed during recording, reloading recorder")
+        prepareRecorderForCurrentDevices()
+    }
+
+    /// Re-resolve the configured input device against the devices present
+    /// right now and rebuild the engine bound to it.
+    private func prepareRecorderForCurrentDevices() {
+        reloadRecorderAfterRecording = false
         recorder.preferredDeviceID = AudioDeviceManager.resolveConfiguredDeviceID(
             uid: config.audioInputDeviceUID,
             legacyID: config.audioInputDeviceID

--- a/Sources/OpenWisprLib/AudioDeviceManager.swift
+++ b/Sources/OpenWisprLib/AudioDeviceManager.swift
@@ -81,6 +81,43 @@ class AudioDeviceManager {
         return listInputDevices().first(where: { $0.uid == uid })?.id
     }
 
+    private static var deviceChangeHandler: (() -> Void)?
+    private static var deviceChangeDebounce: DispatchWorkItem?
+    private static var deviceChangeListener: AudioObjectPropertyListenerBlock?
+
+    /// Invoke `onChange` (on the main queue) whenever the set of audio
+    /// devices or the default input device changes. Bursts of change events
+    /// (a Bluetooth headset connecting fires several) are coalesced.
+    static func startDeviceChangeMonitoring(onChange: @escaping () -> Void) {
+        guard deviceChangeListener == nil else {
+            deviceChangeHandler = onChange
+            return
+        }
+        deviceChangeHandler = onChange
+
+        let listener: AudioObjectPropertyListenerBlock = { _, _ in
+            deviceChangeDebounce?.cancel()
+            let work = DispatchWorkItem { deviceChangeHandler?() }
+            deviceChangeDebounce = work
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: work)
+        }
+        deviceChangeListener = listener
+
+        for selector in [kAudioHardwarePropertyDevices, kAudioHardwarePropertyDefaultInputDevice] {
+            var address = AudioObjectPropertyAddress(
+                mSelector: selector,
+                mScope: kAudioObjectPropertyScopeGlobal,
+                mElement: kAudioObjectPropertyElementMain
+            )
+            AudioObjectAddPropertyListenerBlock(
+                AudioObjectID(kAudioObjectSystemObject),
+                &address,
+                DispatchQueue.main,
+                listener
+            )
+        }
+    }
+
     static func getDeviceUID(deviceID: AudioDeviceID) -> String? {
         var address = AudioObjectPropertyAddress(
             mSelector: kAudioDevicePropertyDeviceUID,

--- a/Sources/OpenWisprLib/AudioRecorder.swift
+++ b/Sources/OpenWisprLib/AudioRecorder.swift
@@ -8,6 +8,14 @@ class AudioRecorder {
     private var currentOutputURL: URL?
     var preferredDeviceID: AudioDeviceID?
 
+    /// Called (on the main queue) when the system invalidates the engine's
+    /// I/O configuration — an audio device was added or removed, or the
+    /// default device changed. The engine stops delivering buffers to its tap
+    /// at that point, so the owner should cancel any in-flight recording and
+    /// reload().
+    var onConfigurationChange: (() -> Void)?
+    private var configChangeObserver: NSObjectProtocol?
+
     func prewarm() {
         guard audioEngine == nil else { return }
 
@@ -21,10 +29,22 @@ class AudioRecorder {
         _ = engine.inputNode
         engine.prepare()
         audioEngine = engine
+
+        configChangeObserver = NotificationCenter.default.addObserver(
+            forName: .AVAudioEngineConfigurationChange,
+            object: engine,
+            queue: .main
+        ) { [weak self] _ in
+            self?.onConfigurationChange?()
+        }
     }
 
     /// Stop and release the engine. Call before changing input device or on shutdown.
     func teardown() {
+        if let observer = configChangeObserver {
+            NotificationCenter.default.removeObserver(observer)
+            configChangeObserver = nil
+        }
         if isRecording {
             audioEngine?.inputNode.removeTap(onBus: 0)
             isRecording = false

--- a/Sources/OpenWisprLib/RecordingLifecycle.swift
+++ b/Sources/OpenWisprLib/RecordingLifecycle.swift
@@ -54,6 +54,14 @@ struct RecordingLifecycle {
         return isReady ? .prepareRecorder : .none
     }
 
+    /// The user asked to rebuild the audio engine from the menu bar (manual
+    /// recovery when the engine is stranded). Same decision as an audio
+    /// configuration change: cancel any in-flight recording — its tap is
+    /// likely dead — otherwise just rebuild the recorder.
+    mutating func manualEngineRestart(isReady: Bool) -> Action {
+        audioConfigurationChanged(isReady: isReady)
+    }
+
     mutating func recordingStartFailed() {
         isRecording = false
     }

--- a/Sources/OpenWisprLib/RecordingLifecycle.swift
+++ b/Sources/OpenWisprLib/RecordingLifecycle.swift
@@ -42,6 +42,18 @@ struct RecordingLifecycle {
         isReady ? .prepareRecorder : .none
     }
 
+    /// The audio engine's I/O configuration was invalidated (an audio device
+    /// was added or removed, or the default device changed). Any in-flight
+    /// recording is already broken — its tap stops receiving buffers — so
+    /// cancel it; otherwise rebuild the recorder so the next recording works.
+    mutating func audioConfigurationChanged(isReady: Bool) -> Action {
+        if isRecording {
+            isRecording = false
+            return .cancelRecording
+        }
+        return isReady ? .prepareRecorder : .none
+    }
+
     mutating func recordingStartFailed() {
         isRecording = false
     }

--- a/Sources/OpenWisprLib/StatusBarController.swift
+++ b/Sources/OpenWisprLib/StatusBarController.swift
@@ -19,6 +19,7 @@ class StatusBarController: NSObject {
 
     var reprocessHandler: ((URL) -> Void)?
     var onConfigChange: ((Config) -> Void)?
+    var restartAudioHandler: (() -> Void)?
 
     enum State {
         case idle
@@ -325,6 +326,10 @@ class StatusBarController: NSObject {
         reloadItem.target = self
         menu.addItem(reloadItem)
 
+        let restartAudioItem = NSMenuItem(title: "Restart Audio Engine", action: #selector(restartAudioEngine), keyEquivalent: "")
+        restartAudioItem.target = self
+        menu.addItem(restartAudioItem)
+
         let openItem = NSMenuItem(title: "Open Configuration", action: #selector(openConfiguration), keyEquivalent: "o")
         openItem.target = self
         menu.addItem(openItem)
@@ -338,6 +343,10 @@ class StatusBarController: NSObject {
     @objc private func reloadConfiguration() {
         guard let delegate = NSApplication.shared.delegate as? AppDelegate else { return }
         delegate.reloadConfig()
+    }
+
+    @objc private func restartAudioEngine() {
+        restartAudioHandler?()
     }
 
     @objc private func openConfiguration() {

--- a/Tests/OpenWisprTests/RecordingLifecycleTests.swift
+++ b/Tests/OpenWisprTests/RecordingLifecycleTests.swift
@@ -44,6 +44,24 @@ final class RecordingLifecycleTests: XCTestCase {
         XCTAssertEqual(lifecycle.systemDidWake(isReady: true), .prepareRecorder)
     }
 
+    func testAudioConfigurationChangeWhileRecordingCancelsInsteadOfStopping() {
+        var lifecycle = RecordingLifecycle()
+
+        XCTAssertEqual(lifecycle.keyDown(toggleMode: false), .startRecording)
+        XCTAssertEqual(lifecycle.audioConfigurationChanged(isReady: true), .cancelRecording)
+        XCTAssertFalse(lifecycle.isRecording)
+        XCTAssertEqual(lifecycle.keyDown(toggleMode: false), .startRecording)
+        XCTAssertEqual(lifecycle.keyUp(toggleMode: false), .stopRecording)
+    }
+
+    func testAudioConfigurationChangeWhileIdlePreparesOnlyWhenReady() {
+        var lifecycle = RecordingLifecycle()
+
+        XCTAssertEqual(lifecycle.audioConfigurationChanged(isReady: false), .none)
+        XCTAssertEqual(lifecycle.audioConfigurationChanged(isReady: true), .prepareRecorder)
+        XCTAssertFalse(lifecycle.isRecording)
+    }
+
     func testStartFailureReturnsLifecycleToIdle() {
         var lifecycle = RecordingLifecycle()
 

--- a/Tests/OpenWisprTests/RecordingLifecycleTests.swift
+++ b/Tests/OpenWisprTests/RecordingLifecycleTests.swift
@@ -62,6 +62,21 @@ final class RecordingLifecycleTests: XCTestCase {
         XCTAssertFalse(lifecycle.isRecording)
     }
 
+    func testManualEngineRestartWhileRecordingCancels() {
+        var lifecycle = RecordingLifecycle()
+
+        XCTAssertEqual(lifecycle.keyDown(toggleMode: false), .startRecording)
+        XCTAssertEqual(lifecycle.manualEngineRestart(isReady: true), .cancelRecording)
+        XCTAssertFalse(lifecycle.isRecording)
+    }
+
+    func testManualEngineRestartWhileIdlePreparesRecorder() {
+        var lifecycle = RecordingLifecycle()
+
+        XCTAssertEqual(lifecycle.manualEngineRestart(isReady: true), .prepareRecorder)
+        XCTAssertFalse(lifecycle.isRecording)
+    }
+
     func testStartFailureReturnsLifecycleToIdle() {
         var lifecycle = RecordingLifecycle()
 


### PR DESCRIPTION
## Problem

The audio engine is created once at startup and never rebuilt when the audio device landscape changes underneath it — Bluetooth headset connecting/disconnecting, iPhone Continuity mic appearing, Teams/Zoom virtual devices registering, a USB mic replug. Once the engine's binding goes stale, every recording produces a header-only WAV: the hotkey fires and a file is created, but the input tap delivers no buffers, so dictation silently types nothing until the daemon is manually restarted.

This is the same failure mode #83 fixed for sleep/wake, just triggered by device changes instead. It's the natural next case after #77 (breaks after sleep) and #67 (breaks after reboot/replug).

## Fix

**Automatic recovery** wired through the existing `reload()` machinery on two complementary signals:

- **`AVAudioEngineConfigurationChange`** (the engine's I/O config was invalidated — it actually died): cancel any in-flight recording, discard the partial file, and rebuild. Mirrors the sleep path.
- **CoreAudio device-list / default-input listeners** (topology changed while idle): re-resolve the configured device UID and rebuild proactively, debounced to coalesce event bursts. If a recording is in flight the engine usually survives a topology change, so the rebuild is deferred until it stops rather than killing the recording.

The decision logic lives in `RecordingLifecycle.audioConfigurationChanged(isReady:)`, kept pure and unit-tested like the existing sleep/wake actions.

**Manual "Restart Audio Engine" menu item** as a complementary escape hatch: rebuilds the engine bound to the currently configured input device from the menu bar, without changing config or restarting the app — for the rare case the engine is stranded but no observer fired. Routed through `RecordingLifecycle.manualEngineRestart(isReady:)` so it shares the same pure, tested decision (cancel any in-flight recording, otherwise just rebuild).

## Tests

Adds unit tests for both new lifecycle decisions. Full suite passes (`swift test`, 128 tests).